### PR TITLE
v1.137.0 — The clock waits for the player

### DIFF
--- a/docs/Changelog-Archive.md
+++ b/docs/Changelog-Archive.md
@@ -33,6 +33,7 @@ Newest first. Where a narrative's own label disagrees with git, the real shippin
 given and the label is kept as an alias — **the labels in this document are not reliable keys**:
 four separate commits are titled `v1.107.0`, nine are titled `v1.80.3`.
 
+- **v1.137.0** — [THE CLOCK WAITS FOR THE PLAYER](#v1-137-0-the-clock-waits-for-the-player)
 - **v1.136.0** — [THE SHEET IS THE CARD YOU PRESSED, AND IT FINALLY OUTRANKS IT](#v1-136-0-the-sheet-is-the-card-you-pressed-and-it)
 - **v1.135.1** — [THE EXPIRY STOPS FLASHING, AND THE COMMIT GETS ITS CAMERA](#v1-135-1-the-expiry-stops-flashing-and-the-commit)
 - **v1.135.0** — [THE ROLE WORD RIDES ITS ORB, AND SPENT MEANS SPENT](#v1-135-0-the-role-word-rides-its-orb-and-spent-me)
@@ -3548,6 +3549,39 @@ does the two-step armed delete and its 12px miss-distance from Share; each glyph
 **`[data-lists-target]` IS RETIRED (v1.103.3).** it existed to make v1.99.5's silent default destination legible, and v1.102.0 removed the silent default, so it was naming a fact that had stopped being true (owner: it "shouldnt exist"). `targetList()` survives as the picker's `[data-picker-default]` ordering, which is an OFFER, not a decision.
 
 <a id="v1-129-8-the-capture-star"></a>
+
+## v1.137.0 — THE CLOCK WAITS FOR THE PLAYER
+
+### THE CLOCK WAITS FOR THE PLAYER (v1.137.0)
+
+Owner: *"The drill countdown starts during page load — a first-time Guest can land on 'TOO
+SLOW · −4%' before ever interacting … no drill timer starts until the user's first real
+interaction AND the question card is fully visible; add a first-session grace multiplier
+(~1.5×) for brand-new users. Keep full time pressure once engaged — the pressure is a feature,
+the loading penalty is the bug."*
+
+The v1.134.0 pause-immune clock made the load bite: the window armed at question mount and
+drained through the boot itself. Now `_armLandClock` refuses to arm until `_clockGateOpen()` —
+`_engaged` (a document-level once+capture latch on pointerdown/pointermove/keydown/touchstart;
+a wrap-scoped listener measurably misses hovers over root-plane overlays) AND the card visible
+(`_landHidden()`'s holders). An early arm parks and refires from `_engage` or the tick. Two
+findings en route: (1) the park initially held the clock-bar ELEMENT, which the deck backfill's
+re-render detached — the disarm then styled a bar nobody saw (transition "" on a
+correct-looking build); the park is a flag now and the bar resolves at arm time from the live
+card. (2) The grace multiplier reuses `_returningVisitor()` — the one latched definition of
+"been here before" — so every fresh-profile e2e window is 13.5s, not 9s. `j.land()` now ends
+with a real corner mouse-move (`j.engage()`), since a journey that lands is simulating a
+playing user; the three boot-only clock specs engage explicitly.
+
+The feature cost 2,012 raw bundle bytes and pushed the first-hand gzip 104 over its 385,000
+ratchet. The ceiling stands: the review's #1 cheap win paid the bill instead — Sora and Archivo
+(dead since applyFont hard-coded Space Grotesk; the fontStack map had no callers) left both
+font links and the bundle, plus small shaves (shorter seam names, the useless passive flag, a
+plain ease on the bar reset). Green at the same ceiling, and production browsers stop
+downloading two font families.
+
+Mutants Ma (gate dropped — arms on mount), Mb (grace dropped), Mc (latch removed) killed by the
+new landing-card spec. Gen suite not re-baselined (its clock-timing rows will shift).
 
 ## v1.136.0 — THE SHEET IS THE CARD YOU PRESSED, AND IT FINALLY OUTRANKS IT
 

--- a/docs/Neural.md
+++ b/docs/Neural.md
@@ -229,7 +229,13 @@ anything that puts the question away — the ✕, a background tap, the pane, an
 DECLINE it (`land_q_declined`, mapped to the same funnel side-mark; momentum untouched). The
 penalty exists only for letting it expire while it faces you. **The question clock never
 pauses** (v1.134.0, owner: "that's our test to the user") — it drains on the real game frame,
-staged boards and internal pauses included; the last three seconds pulse the card itself
+staged boards and internal pauses included — **but it never STARTS before the player does**
+(v1.137.0, owner: "a first-time Guest can land on TOO SLOW · −4% before ever interacting"): no
+window arms until the first real interaction (click, keypress, graph hover — one document-level
+once+capture latch, `_engage`) AND the question card is visible; an early arm parks in
+`_clockWait` (a FLAG — the bar element resolves at arm time, because the card can re-render
+between park and engagement) and fires the moment both hold. Brand-new visitors
+(`_returningVisitor()` false) get a 1.5× grace window; returning players keep full pressure; the last three seconds pulse the card itself
 (`ng-clock-hot` — a MARKER class since v1.135.1: the pulse is frame-driven border/box-shadow
 writes in `_tickDecision`, because a CSS animation on the card replayed its entry animation and
 flashed; the disarm eases both the glow and the clock bar off through one-shot transitions,

--- a/e2e/dsl.ts
+++ b/e2e/dsl.ts
@@ -749,6 +749,19 @@ export class Journey {
     // settle before returning: from here on, the
     // landing question either exists or this state does not ask one
     await this.landQuestion();
+    // v1.137.0: the question clock waits for the player's first REAL interaction — a journey
+    // that lands is simulating a playing user, so it engages the way one would (the corner is
+    // dead space: no node, no overlay, no game effect beyond the latch).
+    await this.engage();
+    return this;
+  }
+
+  /** The first real interaction, minimally: a mouse move the document-level latch can see.
+   *  Journeys about the PRE-engagement state must simply not call land()/engage(). */
+  async engage() {
+    await this.page.mouse.move(4, 4);
+    await this.page.mouse.move(6, 6); // two moves: the first can be swallowed as position-init
+    await this.advance(120);
     return this;
   }
 

--- a/e2e/journeys/announcer-coherence.spec.ts
+++ b/e2e/journeys/announcer-coherence.spec.ts
@@ -129,6 +129,7 @@ test("@curated a Decide countdown does not survive staging another node", async 
   const j = journey(page);
   await j.boot("/");
   await j.advance(6000);
+  await j.engage(); // v1.137.0: the clock waits for the player — this journey plays one
 
   // burn the live window down into the <=3s warning band, where the countdown is written
   for (let i = 0; i < 40; i++) {
@@ -212,6 +213,7 @@ test("the sentences after an expiry survive the hand being torn down", async ({ 
   const j = journey(page);
   await j.boot("/");
   await j.advance(6000);
+  await j.engage(); // v1.137.0: the clock waits for the player — this journey plays one
 
   const seen: string[] = [];
   for (let i = 0; i < 220; i++) {
@@ -255,6 +257,7 @@ test("@curated the clock running out reveals the answer, says so, and steals not
   const j = journey(page);
   await j.boot("/");
   await j.advance(6000);
+  await j.engage(); // v1.137.0: the clock waits for the player — this journey plays one
 
   const handBefore = await page.evaluate(() => ((window as any).__neural.optionIdxs || []).length);
   // walk the announcer at 100ms so the ORDER of the sentences is observed, not inferred
@@ -291,6 +294,7 @@ test("a timed-out question costs the answer, not the exchange", async ({ page })
   const j = journey(page);
   await j.boot("/");
   await j.advance(6000);
+  await j.engage(); // v1.137.0: the clock waits for the player — this journey plays one
   for (let i = 0; i < 240; i++) {
     await j.advance(100);
     const b = (await j.beats()).map((x) => x.beat);

--- a/e2e/journeys/landcard-modes.spec.ts
+++ b/e2e/journeys/landcard-modes.spec.ts
@@ -560,6 +560,7 @@ test("@curated the meter mirrors Win-left, and the clock drains through pause in
     await j.advance(400)
   }
 
+  await j.engage() // v1.137.0: the clock waits for the player — this journey plays one
   // (1) the mirrored meter
   const left = await page.evaluate(async () => {
     const a: any = (window as any).__neural

--- a/e2e/journeys/landing-card.spec.ts
+++ b/e2e/journeys/landing-card.spec.ts
@@ -209,6 +209,7 @@ test("@curated a timed-out question is spent — a late click grades nothing", a
     await page.evaluate(() => document.body.getBoundingClientRect().top)
     await j.advance(400)
   }
+  await j.engage() // v1.137.0: the clock waits for the player — this journey plays one
   const armed = await page.evaluate(() => {
     const a: any = (window as any).__neural
     return !!(a._decision && a._decision.remaining != null && a._mc && a._mc.surface === "land")
@@ -305,6 +306,7 @@ test("@curated expiry is fluid — no re-entry replay, the bar eases home", asyn
     await page.evaluate(() => document.body.getBoundingClientRect().top)
     await j.advance(400)
   }
+  await j.engage() // v1.137.0: the clock waits for the player — this journey plays one
   const armed = await page.evaluate(() => {
     const a: any = (window as any).__neural
     return !!(a._decision && a._decision.remaining != null && a._landEl)
@@ -343,4 +345,73 @@ test("@curated expiry is fluid — no re-entry replay, the bar eases home", asyn
   expect(after.barTransition, "the bar eases home through a transition").toContain("transform")
   expect(after.barTransform).toBe("scaleX(0)")
   expect(after.barBg, "and sheds the hot red for its armed base").toBe("rgb(159, 176, 208)")
+})
+
+/**
+ * THE CLOCK WAITS FOR THE PLAYER (v1.137.0). Owner: "The drill countdown starts during page
+ * load — a first-time Guest can land on TOO SLOW · −4% before ever interacting … no drill
+ * timer starts until the user's first real interaction AND the question card is fully visible;
+ * add a first-session grace multiplier (~1.5×) for brand-new users. Keep full time pressure
+ * once engaged."
+ * Mutants that must die: arming immediately (gate dropped); the 1.5× grace dropped; the
+ * document-level latch removed (a real mouse move must arm it).
+ */
+test("@curated no clock before the first real interaction — then full pressure, with new-user grace", async ({
+  page,
+}) => {
+  const j = journey(page)
+  await j.boot("/Positions/Side-Control/Bottom") // boot only — NO land(), NO engagement
+  await j.advance(9000) // a long, slow "page load"
+  for (let i = 0; i < 3; i++) {
+    await page.evaluate(() => document.body.getBoundingClientRect().top)
+    await j.advance(500)
+  }
+  const idle = await page.evaluate(() => {
+    const a: any = (window as any).__neural
+    return {
+      engaged: !!a._engaged,
+      armed: !!(a._decision && a._decision.remaining != null),
+      parked: !!a._cwArm,
+      expired: (a.beats || []).some((b: any) => b.beat === "land_q_expired"),
+      qMod: a._qMod || 0,
+      cardUp: !!a._landEl,
+    }
+  })
+  expect(idle.cardUp, "the landing question is on screen").toBe(true)
+  expect(idle.engaged, "nobody has touched anything").toBe(false)
+  expect(idle.armed, "so no clock is running").toBe(false)
+  expect(idle.parked, "the arm is parked, waiting").toBe(true)
+  expect(idle.expired, "and nothing ever expired during load").toBe(false)
+  expect(idle.qMod, "no loading penalty").toBe(0)
+
+  // the first REAL interaction — a graph hover the document-level latch can see
+  await page.mouse.move(4, 4)
+  await page.mouse.move(6, 6)
+  await j.advance(300)
+  const armed = await page.evaluate(() => {
+    const a: any = (window as any).__neural
+    return {
+      engaged: !!a._engaged,
+      total: a._decision ? a._decision.total : null,
+      base: a.get("decisionSec", 9) * 1000,
+      returning: a._returningVisitor(),
+      beat: (a.beats || []).some((b: any) => b.beat === "engaged"),
+    }
+  })
+  expect(armed.engaged, "one hover engages").toBe(true)
+  expect(armed.beat).toBe(true)
+  expect(armed.returning, "a fresh profile is a brand-new user").toBe(false)
+  expect(armed.total, "…who gets the 1.5× grace window").toBe(armed.base * 1.5)
+
+  // a returning visitor gets the full-pressure window — same seam, marker present
+  const vet = await page.evaluate(() => {
+    const a: any = (window as any).__neural
+    try { localStorage.setItem("bjj-neural-firstroll", "1") } catch (e) {}
+    a._returning = null // re-derive the latched answer from the marker
+    a._disarmLandClock()
+    a._decision = { remaining: null, total: null, warned: 0, pick: null, opts: [] }
+    a._armLandClock(a._landEl ? a._landEl.querySelector("[data-land-clock]") : null, true)
+    return { total: a._decision.total, base: a.get("decisionSec", 9) * 1000 }
+  })
+  expect(vet.total, "a returning visitor keeps full pressure").toBe(vet.base)
 })

--- a/neural/src/app.src.jsx
+++ b/neural/src/app.src.jsx
@@ -2518,7 +2518,6 @@ class Component extends DCLogic {
     b.addEventListener("click", onClick);
     return b;
   }
-  fontStack(name) { return ({ Grotesk: "'Space Grotesk'", Sora: "'Sora'", Archivo: "'Archivo'", Jakarta: "'Plus Jakarta Sans'" }[name] || "'Space Grotesk'"); }
   applyFont() {
     const stack = "'Space Grotesk'";
     this._displayFam = stack;
@@ -11531,10 +11530,41 @@ class Component extends DCLogic {
   // doesn't choose for you. You still choose." (owner). The old hesitation branch (v1.129.0,
   // "you hesitated — they move first") is retired with the hand clock; its story is in the
   // archive under v1.129.0 and v1.133.0.
-  _armLandClock(clockEl) {
+  // ── THE CLOCK WAITS FOR THE PLAYER (v1.137.0, owner) ─────────────────────────────────────
+  // "The drill countdown starts during page load — a first-time Guest can land on TOO SLOW ·
+  // −4% before ever interacting." The pause-immune clock (v1.134.0) made this bite harder: it
+  // drains through the load itself. So no window arms until the user's FIRST real interaction
+  // (click, keypress, graph hover — `_engage()` is called from all three input heads) AND the
+  // question card is actually visible (`_landHidden()` asks the holders). An arm requested
+  // before that parks in `_cwArm` and fires from `_engage`/`_tickDecision` the moment both
+  // are true. The pressure itself is untouched — once engaged, the full window runs.
+  _engage() {
+    if (!this._engaged) { this._engaged = true; this.fx("engaged", {}); }
+    this._tryArmClock();
+  }
+  _clockGate() {
+    return !!this._engaged && !!this._landEl && !this._landHidden();
+  }
+  _tryArmClock() {
+    if (!this._cwArm || !this._clockGate()) return;
+    this._cwArm = null;
+    // RESOLVE THE BAR AT ARM TIME, never from the park: the card can re-render (deck backfill)
+    // between the parked mount and the first interaction, and a parked DOM reference then
+    // points at a DETACHED track — the disarm would style an element nobody sees while the
+    // live bar keeps its authored initial state (measured: transition "" on a correct-looking
+    // bar). The live card is the only truth.
+    this._armLandClock(this._landEl ? this._landEl.querySelector("[data-land-clock]") : null, true);
+  }
+  _armLandClock(clockEl, gateChecked) {
     const d = this._decision;
     if (!d) return;
-    const sec = this._decisionDsec || this.get("decisionSec", 9);
+    if (!gateChecked && !this._clockGate()) { this._cwArm = true; return; }
+    this._cwArm = null;
+    // FIRST-SESSION GRACE (owner: "~1.5× for brand-new users"): a visitor with no prior session
+    // marker gets a longer window while they learn what the clock even is. `_returningVisitor`
+    // is the ONE latched definition of "been here before" — reused, never re-derived.
+    const grace = this._returningVisitor() ? 1 : 1.5;
+    const sec = (this._decisionDsec || this.get("decisionSec", 9)) * grace;
     d.remaining = sec * 1000; d.total = sec * 1000; d.warned = 0;
     this._landClockEl = clockEl || null;
     if (clockEl) { clockEl.style.transition = ""; this._clockBase = clockEl.style.background; } // frame-driven writes must not lag through a leftover reset transition
@@ -11542,6 +11572,7 @@ class Component extends DCLogic {
     this._armDeckExpire();
   }
   _disarmLandClock() {
+    this._cwArm = null; // a parked arm dies with its window
     const d = this._decision;
     if (d) { d.remaining = null; d.total = null; }
     if (this._landEl && this._landEl.classList.contains("ng-clock-hot")) {
@@ -11559,7 +11590,7 @@ class Component extends DCLogic {
       // color it was armed with, instead of jumping. The drain itself stays frame-driven —
       // the transition exists only for this one write (the next arm clears it).
       const bar = this._landClockEl;
-      bar.style.transition = "transform .45s cubic-bezier(.2,.7,.2,1), background .45s ease";
+      bar.style.transition = "transform .45s ease, background .45s ease";
       bar.style.transform = "scaleX(0)";
       if (this._clockBase) bar.style.background = this._clockBase;
       this._landClockEl = null;
@@ -11636,6 +11667,7 @@ class Component extends DCLogic {
     this.setEvent("Too slow", "Answer revealed \u00b7 \u22124% on this exchange" + (broke >= 2 ? " \u00b7 \u00d7" + broke + " momentum gone" : ""), "bad");
   }
   _tickDecision(gdt) {
+    if (this._cwArm) this._tryArmClock(); // the card can become visible after engagement
     const d = this._decision;
     if (!d || d.remaining == null || this._checkpoint) return; // Q002 lives on: the checkpoint quiz is untimed — and so is every HAND now (v1.133.0); this window times the QUESTION only
     d.remaining -= gdt * 1000;
@@ -12614,6 +12646,15 @@ class Component extends DCLogic {
   }
   sbOffset() { const w = this.W || (this.wrapRef.current ? this.wrapRef.current.clientWidth : 1200); return w <= 640 ? 0 : 360; }
   attachInput() {
+    // THE ENGAGEMENT LATCH IS DOCUMENT-LEVEL, ONE SEAM (v1.137.0): root-plane overlays (the
+    // announcer, the film strip, the landing card) cover much of the screen, so a wrap-scoped
+    // listener misses real hovers over them — measured: elementFromPoint(640,300) resolved to a
+    // root-plane div outside the wrap. Capture-phase, once-only, all three arrival gestures.
+    {
+      const eng = () => this._engage();
+      for (const ev of ["pointerdown", "pointermove", "keydown"])
+        document.addEventListener(ev, eng, { once: true, capture: true });
+    }
     const el = this.wrapRef.current;
     let dragging = false, lx = 0, ly = 0, dsx = 0, dsy = 0, moved = 0;
     const ptrs = new Map();

--- a/neural/src/helmet.html
+++ b/neural/src/helmet.html
@@ -1,6 +1,6 @@
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=Sora:wght@500;600;700&family=Archivo:wght@500;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
 <style>
   html,body{margin:0;padding:0;height:100%;background:#1a1a2e;overflow:hidden;}
   *{box-sizing:border-box;}

--- a/neural/src/xdc-template.html
+++ b/neural/src/xdc-template.html
@@ -1,7 +1,7 @@
 
 <helmet>
 <link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=Sora:wght@500;600;700&family=Archivo:wght@500;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
 <link href="challenge-ui.css" rel="stylesheet">
 <link href="challenge-collection.css" rel="stylesheet">
 <link href="challenge-feedback.css" rel="stylesheet">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bjjgraph",
-  "version": "1.136.0",
+  "version": "1.137.0",
   "description": "BJJ knowledge graph and state machine",
   "scripts": {
     "postinstall": "cd source && npm install",

--- a/tests/artifacts/first_hand_payload.json
+++ b/tests/artifacts/first_hand_payload.json
@@ -1,11 +1,11 @@
 {
  "_meta": {
   "note": "Written by e2e/journeys/payload-first-hand.spec.ts. Observed only — the ceilings live in budget_neural.json.",
-  "measured_at": "2026-08-26T11:30:11.622Z"
+  "measured_at": "2026-08-26T15:30:20.397Z"
  },
  "request_count": 20,
- "first_hand_raw_bytes": 1693165,
- "first_hand_gzip_bytes": 384865,
+ "first_hand_raw_bytes": 1693612,
+ "first_hand_gzip_bytes": 384995,
  "start_position": "Gogoplata Control Top",
  "charged_from_disk": [],
  "heaviest": [
@@ -16,8 +16,8 @@
   },
   {
    "path": "/static/neural/app/neural.js",
-   "raw": 475070,
-   "gzip": 141366
+   "raw": 475517,
+   "gzip": 141496
   },
   {
    "path": "/static/neural/flashcards/_index.json",


### PR DESCRIPTION
## What

Owner report: *"The drill countdown starts during page load — a first-time Guest can land on 'TOO SLOW · −4%' before ever interacting."*

- **No question/drill window arms** until the user's first real interaction (click / keypress / graph hover — one document-level `once+capture` latch) **and** the question card is visible. Early arms park in a flag and fire the moment both hold. A wrap-scoped listener measurably misses hovers over root-plane overlays, hence document-level.
- **First-session grace ~1.5×** for brand-new users, via the existing `_returningVisitor()` latch — the one definition of "been here before". Returning players keep full pressure; once engaged, nothing weakens.
- The park holds a **flag, not the bar element** — the deck backfill can re-render the card between park and engagement, leaving a parked DOM reference detached (found live: the disarm styled a bar nobody saw).
- `j.land()` now ends with a real corner mouse-move (`j.engage()`); five boot-only clock journeys engage explicitly.
- **Payload**: the feature's ~2KB pushed first-hand gzip 104 B over its 385,000 ratchet. The ceiling stands — the dead Sora/Archivo font families (nothing styles them; `applyFont` hard-codes Space Grotesk) left both font links and the bundle instead. Green at the unchanged ceiling, and production browsers stop downloading two font families.

## Gates

- Curated 194/0 · payload first-hand green at the unchanged ceiling
- Mutants killed: gate dropped (arms on mount) · grace dropped · latch removed
- Gen suite not re-baselined (its clock-timing rows will shift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFWJUdvvb6uw64B5h7VAv7