### PR TITLE
v1.138.0 — The expiry sentence is a lease, not a resident

### DIFF
--- a/docs/Changelog-Archive.md
+++ b/docs/Changelog-Archive.md
@@ -33,6 +33,7 @@ Newest first. Where a narrative's own label disagrees with git, the real shippin
 given and the label is kept as an alias — **the labels in this document are not reliable keys**:
 four separate commits are titled `v1.107.0`, nine are titled `v1.80.3`.
 
+- **v1.138.0** — [THE EXPIRY SENTENCE IS A LEASE, NOT A RESIDENT](#v1-138-0-the-expiry-sentence-is-a-lease-not-a-res)
 - **v1.136.0** — [THE SHEET IS THE CARD YOU PRESSED, AND IT FINALLY OUTRANKS IT](#v1-136-0-the-sheet-is-the-card-you-pressed-and-it)
 - **v1.135.1** — [THE EXPIRY STOPS FLASHING, AND THE COMMIT GETS ITS CAMERA](#v1-135-1-the-expiry-stops-flashing-and-the-commit)
 - **v1.135.0** — [THE ROLE WORD RIDES ITS ORB, AND SPENT MEANS SPENT](#v1-135-0-the-role-word-rides-its-orb-and-spent-me)
@@ -3548,6 +3549,21 @@ does the two-step armed delete and its 12px miss-distance from Share; each glyph
 **`[data-lists-target]` IS RETIRED (v1.103.3).** it existed to make v1.99.5's silent default destination legible, and v1.102.0 removed the silent default, so it was naming a fact that had stopped being true (owner: it "shouldnt exist"). `targetList()` survives as the picker's `[data-picker-default]` ordering, which is an OFFER, not a decision.
 
 <a id="v1-129-8-the-capture-star"></a>
+
+## v1.138.0 — THE EXPIRY SENTENCE IS A LEASE, NOT A RESIDENT
+
+### THE EXPIRY SENTENCE IS A LEASE, NOT A RESIDENT (v1.138.0)
+
+Owner: *"The 'Answer revealed · −4% on this exchange' banner stays pinned while exploring other
+cards/nodes — clear or fade it when focus moves to another card (or after ~5s)."* The announcer
+recon confirmed the gap: the two expiry sentences were the only long-lived lines with NO owner —
+`_evCountdown`'s machinery never touches them, and all five focus-move seams left them standing.
+Fix, in the announcer's own stamped-owner idiom: `_evExpiry` is set right after each expiry
+`setEvent` (which releases every stamp on its way in, so a successor sentence can never be faded
+by a stale lease), dropped by ONE seam (`_dropExpiryEvent`) from the five focus moves —
+staging, roam, the option sheet, the dossier, deck paging — and aged out at ~5s by the frame
+loop, with the `.ng-evtoast` CSS easing the fade. Mutants Md (drop seam no-op), Me (5s fade
+removed), Mf (setEvent not releasing) killed by the new announcer spec.
 
 ## v1.136.0 — THE SHEET IS THE CARD YOU PRESSED, AND IT FINALLY OUTRANKS IT
 

--- a/docs/Neural.md
+++ b/docs/Neural.md
@@ -270,7 +270,11 @@ exchange and the board comes back. Beat: `hesitated`.
 
 ### The announcer
 
-One slot, and **one subject per label**: the announcer names **who is initiating** ("You go for" /
+One slot, stamped owners. The expiry sentence ("Answer revealed · −4%") is a LEASE since
+v1.138.0 (`_evExpiry`): it drops the moment focus moves — staging, roam, the option sheet, the
+dossier, deck paging, one seam (`_dropExpiryEvent`) — or ~5s after it was written; any newer
+sentence releases the stamp on its way in. And **one subject per label**: the announcer names
+**who is initiating** ("You go for" /
 "Opponent goes for"), and the graph verb names **your posture** toward that move. They can never
 contradict because they answer different questions. Whoever writes the slot owns its lifetime —
 `_tickDecision` stamps `_evCountdown` when it writes the countdown, every other `setEvent` releases

--- a/e2e/journeys/announcer-coherence.spec.ts
+++ b/e2e/journeys/announcer-coherence.spec.ts
@@ -304,3 +304,83 @@ test("a timed-out question costs the answer, not the exchange", async ({ page })
   await j.advance(1500);
   expect((await j.beats()).map((b) => b.beat), "the commit is theirs").toContain("commit");
 });
+
+/**
+ * THE EXPIRY SENTENCE IS A LEASE, NOT A RESIDENT (v1.138.0). Owner: "the 'Answer revealed ·
+ * −4% on this exchange' banner stays pinned while exploring other cards/nodes — clear or fade
+ * it when focus moves to another card (or after ~5s)." The penalty was paid at expiry; the
+ * sentence lets go when attention moves (sheet, stage, roam, dossier, paging — one drop seam)
+ * or ~5s after it was written. Any NEWER sentence releases the stamp on its way in (the
+ * one-slot stamped-owner pattern), so a successor can never be faded by a stale lease.
+ * Mutants that must die: the drop seam a no-op; the 5s fade removed; setEvent not releasing.
+ */
+test("@curated the expiry banner lets go — on focus move, by age, and never a successor", async ({
+  page,
+}) => {
+  const j = journey(page);
+  await j.boot("/Positions/Side-Control/Bottom");
+  await j.advance(7000);
+  for (let i = 0; i < 3; i++) {
+    await page.evaluate(() => document.body.getBoundingClientRect().top);
+    await j.advance(400);
+  }
+  // forward-compatible engagement: real mouse moves (a no-op before the clock-gate PR, the
+  // required first interaction after it)
+  await page.mouse.move(4, 4);
+  await page.mouse.move(6, 6);
+  await j.advance(300);
+  const armed = await page.evaluate(() => {
+    const a: any = (window as any).__neural;
+    return !!(a._decision && a._decision.remaining != null);
+  });
+  expect(armed, "a landing question armed the clock").toBe(true);
+
+  await page.evaluate(() => ((window as any).__neural._decision.remaining = 30));
+  await j.advance(400);
+  const at = await page.evaluate(() => {
+    const a: any = (window as any).__neural;
+    return { kicker: a.evKickerRef.current.textContent, stamped: a._evExpiry != null };
+  });
+  expect(at.kicker, "the expiry announced itself").toBe("Too slow");
+  expect(at.stamped, "and took its lease").toBe(true);
+
+  // focus moves: opening an option sheet drops it at once
+  const drop = await page.evaluate(() => {
+    const a: any = (window as any).__neural;
+    const opt = a._optList && a._optList[0];
+    if (!opt) return null;
+    a.expandOption(opt, () => {});
+    return { opacity: a.evRef.current.style.opacity, stamped: a._evExpiry != null };
+  });
+  expect(drop, "an option to read").not.toBeNull();
+  expect(drop!.opacity, "the banner let go the moment focus moved").toBe("0");
+  expect(drop!.stamped).toBe(false);
+  await page.evaluate(() => (window as any).__neural.closeOptionDetail());
+
+  // by age: a 5s-old lease fades from the frame loop
+  await page.evaluate(() => {
+    const a: any = (window as any).__neural;
+    a.setEvent("Too slow", "Answer revealed · −4% on this exchange", "bad");
+    a._evExpiry = (a.now || 0) - 6;
+  });
+  await j.advance(300);
+  expect(
+    await page.evaluate(() => (window as any).__neural.evRef.current.style.opacity),
+    "the aged banner faded on its own",
+  ).toBe("0");
+
+  // and never a successor: a newer sentence releases the lease on its way in
+  const succ = await page.evaluate(async () => {
+    const a: any = (window as any).__neural;
+    a.setEvent("Too slow", "Answer revealed · −4% on this exchange", "bad");
+    a._evExpiry = (a.now || 0) - 6;
+    a.setEvent("Correct", "Odds up on this exchange", "good"); // the successor releases the stamp
+    return { stamped: a._evExpiry != null };
+  });
+  expect(succ.stamped, "the successor took the slot clean").toBe(false);
+  await j.advance(300);
+  expect(
+    await page.evaluate(() => (window as any).__neural.evRef.current.style.opacity),
+    "and no stale lease fades it",
+  ).toBe("1");
+});

--- a/neural/src/app.src.jsx
+++ b/neural/src/app.src.jsx
@@ -1462,6 +1462,7 @@ class Component extends DCLogic {
     // `clearOptions` drop a countdown for a hand that no longer exists without touching anything
     // else — including the "Time's up" line, which reaches this function and clears the flag here.
     this._evCountdown = null;
+    this._evExpiry = null; // the expiry sentence's lease (v1.138.0) — any newer sentence outranks it
     const k = this.evKickerRef.current, t = this.evTextRef.current, box = this.evRef.current;
     if (k) { k.textContent = kicker; k.style.color = this.toneColor(tone); }
     if (t) {
@@ -3450,6 +3451,7 @@ class Component extends DCLogic {
     if (panel.parentElement !== root) { root.appendChild(panel); panel.style.position = "fixed"; panel.style.zIndex = "50"; }
     this.setPaused(true);           // freeze MOTION while the player reads/confirms (the question clock never pauses — it was declined on the line below)
     this._declineLandQ("sheet");    // reading a move instead of answering = declining (v1.134.0)
+    this._dropExpiryEvent();        // reading a move — the expiry sentence lets go (v1.138.0)
     this.fx("sheet_opened", { technique: (opt && opt.node && opt.node.t) || null });
     // v1.136.0 (owner): the landing card STAYS — the sheet maximizes IN FRONT of it (z:6 over
     // the card's z:5, its shadow falling on it), it does not make the card vanish. This also
@@ -7255,6 +7257,7 @@ class Component extends DCLogic {
     return real[0].idx;
   }
   openDossier(idx, skipCam) {
+    this._dropExpiryEvent(); // reading a node — the expiry sentence lets go (v1.138.0)
     const n = this.nodes && this.nodes[idx]; if (!n) return;
     if (this._pickEl) this.closeListPicker(); // the chooser's anchor is about to be re-rendered away
     this.track("neural_dossier_opened", { node: n.t, node_type: n.ty, mode: "card" });
@@ -7402,6 +7405,7 @@ class Component extends DCLogic {
   }
   _enterRoam() {
     if (this._roam) return;
+    this._dropExpiryEvent(); // roaming away — the expiry sentence lets go (v1.138.0)
     this._roam = true;
     if (this._played && this.rollLog && this.rollLog.length > 1) {
       this._pastRolls = this._pastRolls || [];
@@ -9551,6 +9555,7 @@ class Component extends DCLogic {
   // Clamp at the ends: an edge is an edge, and the mini-deck's modulo wrap loses the reader's
   // place in a deck they are browsing.
   _landPageTo(dir) {
+    this._dropExpiryEvent(); // paging to another card — the expiry sentence lets go (v1.138.0)
     const el = this._landEl;
     if (!el || (this._landMode !== "land" && this._landMode !== "attempt")) return false;
     if (!this._landQ || !this._landQ.key || this._landPage == null) return false;
@@ -10940,6 +10945,7 @@ class Component extends DCLogic {
     }
   }
   stageRollAt(nodeIdx) {
+    this._dropExpiryEvent(); // exploring another node — the expiry sentence lets go (v1.138.0)
     this.rollFromPosition(nodeIdx, true);
     this._staged = this.currentPos;
     this.fx("roll_staged", { position: this.nodes[this.currentPos] ? this.nodes[this.currentPos].t : null, technique: this._stagedTech && this.nodes[this._stagedTech.idx] ? this.nodes[this._stagedTech.idx].t : null });
@@ -11602,6 +11608,7 @@ class Component extends DCLogic {
       const broke = this._breakCombo("slow");
       this._dockLandCard(card);
       this.setEvent("Too slow", "The answer's on the table \u2014 no pump" + (broke >= 2 ? " \u00b7 \u00d7" + broke + " momentum gone" : ""), "bad");
+      this._evExpiry = this.now || 0; // stamped AFTER setEvent (which releases every stamp)
       return;
     }
     // LANDING QUESTION: reveal the mounted block as a miss — the card was shown, so it is spent
@@ -11634,6 +11641,20 @@ class Component extends DCLogic {
     this._landPending = false;
     this.refreshOptionOdds();
     this.setEvent("Too slow", "Answer revealed \u00b7 \u22124% on this exchange" + (broke >= 2 ? " \u00b7 \u00d7" + broke + " momentum gone" : ""), "bad");
+    this._evExpiry = this.now || 0; // stamped AFTER setEvent (which releases every stamp)
+  }
+  // ── THE EXPIRY SENTENCE IS A LEASE, NOT A RESIDENT (v1.138.0, owner) ─────────────────────
+  // "The 'Answer revealed · −4%' banner stays pinned while exploring other cards/nodes." The
+  // penalty was paid at expiry; the sentence's job is done the moment attention moves on. It
+  // fades ~5s after it was written (the frame loop below) or IMMEDIATELY when focus moves —
+  // staging another node, free roam, opening an option sheet, paging the deck, opening a
+  // dossier — through this one drop seam. The stamp survives nothing else: any newer setEvent
+  // releases it (one slot, stamped owners — the _evCountdown pattern).
+  _dropExpiryEvent() {
+    if (this._evExpiry == null) return;
+    this._evExpiry = null;
+    const box = this.evRef.current;
+    if (box) box.style.opacity = "0"; // the .ng-evtoast CSS eases it out
   }
   _tickDecision(gdt) {
     const d = this._decision;
@@ -12546,6 +12567,7 @@ class Component extends DCLogic {
         // the real frame delta. The live roll's own pulse was parked at `startReplay` and is handed
         // back on stop, so nothing of the roll advances here.
         this.updateTravel(this._replay ? dt : gdt);
+        if (this._evExpiry != null && (this.now || 0) - this._evExpiry > 5) this._dropExpiryEvent(); // v1.138.0: the expiry sentence lets go after ~5s
         this._tickDecision(dt); // v1.134.0: the question clock NEVER pauses — "that's our test to the user" (owner); motion still freezes on the internal pause
         this.updateFlash();
         this.updateRipples();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bjjgraph",
-  "version": "1.136.0",
+  "version": "1.138.0",
   "description": "BJJ knowledge graph and state machine",
   "scripts": {
     "postinstall": "cd source && npm install",


### PR DESCRIPTION
## What

Owner report: *"The 'Answer revealed · −4% on this exchange' banner stays pinned while exploring other cards/nodes — clear or fade it when focus moves to another card (or after ~5 s)."*

The announcer recon confirmed the gap: the two expiry sentences were the only long-lived lines with **no owner** — the countdown's stamp machinery never touches them, and all five focus-move seams left them standing.

Fix, in the announcer's own stamped-owner idiom:
- `_evExpiry` stamps the sentence right after each expiry `setEvent` (which releases every stamp on its way in — a successor sentence can never be faded by a stale lease).
- One drop seam (`_dropExpiryEvent`) fires from the five focus moves: staging another node, free roam, the option sheet, the dossier, deck paging.
- The frame loop ages the lease out at ~5 s; the `.ng-evtoast` CSS eases the fade.

## Gates

- Curated 194/0
- Mutants killed: drop seam no-op · 5s fade removed · setEvent not releasing
- The new spec's engagement gesture is raw mouse moves — forward-compatible with #197 (the clock-gate PR). Trivial `package.json` version conflict with #197: merge #197 first, this rebases clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFWJUdvvb6uw64B5h7VAv7