### PR TITLE
v1.136.1 - PostHog stays out of a build with no key, and the skip says so

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
 # PostHog frontend (public project key - used at build time by Quartz)
+# NOTE: the build runs `cd source && npx quartz build`, so dotenv resolves source/.env - NOT this
+# file's directory. A key set only in the repo-root .env never reaches the build, and the emitter
+# then skips the PostHog injection entirely (it prints when it does). That is intentional for local
+# dev: prod's key comes from CI secrets, and dev traffic must not land in the production project.
 POSTHOG_API_KEY=phc_your_project_api_key_here
 POSTHOG_API_HOST=https://your-posthog-proxy.example.com
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bjjgraph",
-  "version": "1.136.0",
+  "version": "1.136.1",
   "description": "BJJ knowledge graph and state machine",
   "scripts": {
     "postinstall": "cd source && npm install",

--- a/source/quartz/plugins/emitters/componentResources.ts
+++ b/source/quartz/plugins/emitters/componentResources.ts
@@ -129,7 +129,25 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
         "https://${cfg.analytics.websiteId}.${cfg.analytics.host ?? "goatcounter.com"}/count")
       document.head.appendChild(goatcounterScript)
     `)
-  } else if (cfg.analytics?.provider === "posthog") {
+  } else if (cfg.analytics?.provider === "posthog" && cfg.analytics.apiKey) {
+    // THE WHOLE INJECTION IS GUARDED, NOT JUST THE `init` LINE BELOW.
+    //
+    // `quartz.config.ts` reads `process.env.POSTHOG_API_KEY || ""` — the `|| ""` is only there to
+    // satisfy the required `apiKey: string` in cfg.ts — and the build runs from `source/`, so
+    // dotenv resolves `source/.env`, which carries no PostHog vars. A local build therefore
+    // emitted a literal `posthog.init("")` into postscript.js: posthog-js rejects the empty token
+    // with a console.error on every dev page load, after fetching array.js from the CDN first.
+    //
+    // Guarding only `init` would still ship the stub above it, and the stub is the problem: it
+    // installs a `window.posthog` whose `capture` is a queue-pushing shim, so every consumer guard
+    // in the app (`app.src.jsx`'s track(), variant.inline.ts's fireExposure) passes and queues
+    // events forever against an instance that never initialised. Dropping the block outright
+    // leaves `window.posthog` undefined, which is the shape those guards were written for and the
+    // one docs/SEO.md already documents ("a no-op when the PostHog token is absent").
+    //
+    // Deliberately NOT fixed here: pointing dotenv at the repo-root .env, which DOES hold the real
+    // phc_ key. That would send local dev traffic into the production project. Prod gets its key
+    // from CI secrets (deploy.yaml / deploy-dev.yaml); dev gets no token at all, by design.
     const phHost = cfg.analytics.host ?? "https://us.i.posthog.com"
     const phUiHost = cfg.analytics.uiHost ? `,ui_host:${JSON.stringify(cfg.analytics.uiHost)}` : ""
     componentResources.afterDOMLoaded.push(`
@@ -138,6 +156,13 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
       posthog.init(${JSON.stringify(cfg.analytics.apiKey)},{api_host:${JSON.stringify(phHost)}${phUiHost},person_profiles:'always'})\`
       document.head.appendChild(posthogScript)
     `)
+  } else if (cfg.analytics?.provider === "posthog") {
+    // THE SKIP PRINTS (CLAUDE.md §6.6): a check that never ran must not read the same as a pass.
+    // Without this line, "no analytics in the bundle" and "analytics silently misconfigured in CI"
+    // produce identical build output.
+    console.log(
+      "PostHog disabled: POSTHOG_API_KEY is empty — no analytics injected into this build",
+    )
   } else if (cfg.analytics?.provider === "tinylytics") {
     const siteId = cfg.analytics.siteId
     componentResources.afterDOMLoaded.push(`


### PR DESCRIPTION
## The bug

A local build emits `posthog.init("")` into `postscript.js`. posthog-js rejects the empty token with a `console.error` on every dev page load — after fetching `array.js` from the CDN first, so dev pages also make a real outbound request to PostHog on every load.

Root cause is not simply "no `.env`": `quartz.config.ts:18` reads `process.env.POSTHOG_API_KEY || ""` (the `|| ""` only satisfies the required `apiKey: string` in `cfg.ts`), and the build runs `cd source && npx quartz build`, so `dotenv/config` resolves **`source/.env`** — which carries only the Supabase vars — never the repo-root `.env` that does hold the key.

## The fix

Guard the **whole** injection, not just the `init` line, and print the skip.

Guarding only `init` would still ship the stub, and the stub is the problem: it installs a `window.posthog` whose `capture` is a queue-pushing shim, so every consumer guard in the app (`app.src.jsx`'s `track()`, `variant.inline.ts`'s `fireExposure`) passes and queues events forever against an instance that never initialised. Dropping the block leaves `window.posthog` undefined — the shape those guards were written for, and the one `docs/SEO.md` already documents.

The skip prints because a check that never ran must not read the same as a pass (§6.6): without it, "no analytics in the bundle" and "analytics misconfigured in CI" produce identical build output. The shape follows the Supabase block four lines below, which already skips its injection when the value is missing.

## Deliberately not done

- **No dev token.** Prod keeps taking its key from CI secrets.
- **dotenv is NOT repointed at the repo-root `.env`**, which does hold the real `phc_` key — that would send local dev traffic straight into the production project. `.env.example` now records which directory the build actually reads, so nobody "fixes" it that way later.

## Verification

Run against the real emitter (minimal corpus, so the same code path in seconds rather than the full ~10 min build):

- **No key** → skip line printed, `0` occurrences of posthog in `postscript.js`, no `posthog.init` anywhere in the output. The only remaining references are `variant.inline.ts`'s guarded `window.posthog?.capture` read, which correctly no-ops, and the static CSP allowlist.
- **`POSTHOG_API_KEY` set** → the init line returns carrying the token. This is the control that proves it is a guard and not a deletion.

`tsc` clean, prettier clean.

## Note for you, unchanged here

`deploy-dev.yaml` uses the **same** `secrets.POSTHOG_API_KEY` as prod, so the dev *preview* deploy already captures into the production project. Pre-existing and out of scope for this PR — flagging it in case you want it separated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLU7pU692LdGPws3Z91niL