### PR TITLE
v1.137.0 - The card behind the sheet stands down until the sheet leaves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -550,6 +550,9 @@ symbol to every version that touched it.
 - **Comments are stripped by the build, so documentation above a constant is FREE — put the reasoning where the change will be made, not here.** Only the copy and the code are on the payload bill. Corollary for this section: a fact with a code site belongs in a comment at that site, and only its TRIGGER TOKEN belongs in CLAUDE.md. What stays here is what has no code site — how the work is measured, surveyed and claimed.
   <br>_(n/a — the admission rule for this section)_
 
+- **…EXCEPT IN `neural/src/helmet.html`, WHERE COMMENTS SHIP.** The rule above is a fact about esbuild, and the app's stylesheet never reaches it: `build.mjs` step 6 lifts the text between `<style>` and `</style>` **verbatim** into `neural.css` — no minifier, no comment stripping — so every CSS comment is downloaded by every visitor. The symptom is a payload gate failing on a change whose *code* is tiny, which reads as "my rule is too big" and is really the paragraph above it. Measured at v1.137.0: a 10-line comment on ONE rule cost **~800 bytes**, against **367** for all of that change's JavaScript, and put `payload-first-hand` **304 bytes over** its gzip ceiling. **Do:** one pointer line in the CSS naming the JS symbol that owns the behaviour, and the reasoning at that symbol, where it is free. Note the inversion this forces on §9 — a helmet-only fact belongs HERE precisely because its code site charges rent. Verify with `grep -c "<phrase>" neural/dist/neural.css neural/dist/neural.js` after `dev:neural:app`: 1 and 0. **Partially pinned:** `payload-first-hand` fails only once the accumulated overrun crosses the ceiling, so it catches the tenth comment, not the first.
+  <br>_(1 · headroom at v1.137.0: first-hand gzip 384,956 of 385,000 — 44 bytes)_
+
 
 ## 7. Content standards, and the affiliate disclosure
 

--- a/e2e/journeys/coldstart-backfill.spec.ts
+++ b/e2e/journeys/coldstart-backfill.spec.ts
@@ -246,13 +246,36 @@ test("cold start: a payload arriving behind the expand sheet renders BEHIND it, 
       cardVisible: cs.opacity !== "0" && cs.visibility === "visible",
       overlap,
       sheetWinsPaint: !!(hit && panel.contains(hit)),
+      // v1.137.0: born under an open sheet = born stood down. This is the ONLY gate on
+      // renderLandCard's `_syncDetailDim()` re-assert — a backfill builds a brand-new element with
+      // fresh, non-inert children, so nothing else re-applies the dim to it.
+      opacity: parseFloat(cs.opacity),
+      marked: card.hasAttribute("data-behind-sheet"),
+      kidsInert: card.children.length > 0 && [...card.children].every((c: any) => c.inert === true),
     };
   });
   expect(stack, "card and sheet both mounted").not.toBeNull();
   expect(stack!.cardVisible, "the backfilled card arrives VISIBLE behind the sheet").toBe(true);
   if (stack!.overlap) expect(stack!.sheetWinsPaint, "the sheet wins the paint where they overlap").toBe(true);
+  expect(stack!.opacity, "...and DIMMED, not at full strength").toBeLessThan(1);
+  expect(stack!.opacity, "...but not hidden — this is a stand-down, not the old hide").toBeGreaterThan(0);
+  expect(stack!.marked, "the backfilled card carries the stand-down marker").toBe(true);
+  expect(stack!.kidsInert, "and its children are born inert").toBe(true);
 
   await page.evaluate(() => (window as any).__neural.closeOptionDetail());
+  await page.waitForTimeout(400);
+  const restored = await page.evaluate(() => {
+    const card = document.querySelector(".ng-landcard") as HTMLElement;
+    if (!card) return null;
+    return {
+      opacity: getComputedStyle(card).opacity,
+      marked: card.hasAttribute("data-behind-sheet"),
+      kidsInert: [...card.children].some((c: any) => c.inert === true),
+    };
+  });
+  expect(restored!.opacity, "closing the sheet hands the backfilled card back").toBe("1");
+  expect(restored!.marked).toBe(false);
+  expect(restored!.kidsInert).toBe(false);
   expect((await read(page)).hasQ, "carrying the question it was owed").toBe(
     true,
   );

--- a/e2e/journeys/keyboard.spec.ts
+++ b/e2e/journeys/keyboard.spec.ts
@@ -31,6 +31,16 @@ test("A-D answer the live question; digits open option sheets", async ({ page })
   const answered0 = (await j.beats()).filter((b) => b.beat === "land_q_answered").length
   expect(answered0, "and answered nothing").toBe(0)
 
+  // ...AND NEITHER DOES A LETTER WHILE THE SHEET IS UP (v1.137.0). The card is still on screen
+  // behind the sheet, but stood down — dimmed and inert — so A-D must not grade it. This is the
+  // assertion that gates `_detailCtx`'s place in `_landHidden()`'s holder list: delete it there
+  // and the letter below scores a question the player is not being asked.
+  await page.keyboard.press("abcd"[mc!.correct])
+  expect(
+    (await j.beats()).filter((b) => b.beat === "land_q_answered").length,
+    "the correct letter does not grade the card standing behind the sheet",
+  ).toBe(0)
+
   await page.keyboard.press("Escape") // back out of the sheet
   expect(await sheetOpen(page), "Esc closed the sheet").toBe(false)
 

--- a/e2e/journeys/option-edge.spec.ts
+++ b/e2e/journeys/option-edge.spec.ts
@@ -644,6 +644,13 @@ test("Settings no longer offers an ordering it does not use", async ({
  * landing card "magically disappears — it should be BEHIND the maximized card, not gone".
  * Mutants that must die: restoring the explainer paragraph; restoring the from→to title;
  * dropping the digit (nodeGlyph instead of catGlyph); re-hiding the landcard on expand.
+ *
+ * v1.137.0 SHARPENS THE LANDCARD HALF. "Behind it" was true of the paint and false of everything
+ * else: the card stayed at full opacity while `_detailCtx` sat in `_landHidden()`'s holder list,
+ * so A-D refused to grade a card that looked completely live. The claim is now "dimmed, present,
+ * and inert" rather than "opacity is exactly 1" — the original mutant still dies, on `> 0` and on
+ * visibility:visible. Also killed here: `_syncDetailDim` no-oping, `closeOptionDetail` reverting
+ * to a bare `_detailCtx = null`, dropping `inert`, and deleting the helmet.html rule.
  */
 test("@curated the sheet keeps the card's name, digit and quiet category — and the landcard stays behind it", async ({
   page,
@@ -680,6 +687,13 @@ test("@curated the sheet keeps the card's name, digit and quiet category — and
       digit: panel.querySelector(".ngglyph")?.innerHTML.includes(">2<") || false,
       landOpacity: land ? getComputedStyle(land).opacity : null,
       landVisibility: land ? getComputedStyle(land).visibility : null,
+      landMarked: land ? land.hasAttribute("data-behind-sheet") : null,
+      // the children are what carry `inert` — the ROOT stays hit-testable on purpose, so that a
+      // tap on the card is still swallowed by attachInput's early-return instead of falling
+      // through to the canvas and destroying the card (see _syncDetailDim)
+      landRootInert: land ? !!(land as any).inert : null,
+      kidsInert: land ? [...land.children].every((c: any) => c.inert === true) : null,
+      kidCount: land ? land.children.length : 0,
       // PAINT ORDER, not z-index arithmetic (§6.3): a point inside both rects must resolve to
       // the sheet — the first cut compared z integers across two stacking contexts and passed
       // green on a build where the card painted over the sheet.
@@ -699,7 +713,139 @@ test("@curated the sheet keeps the card's name, digit and quiet category — and
   expect(r!.explainer, "no explainer paragraph on every open").toBe(false)
   expect(r!.tooltip, "the explainer became the number's tooltip").toContain("By-the-book opponent")
   expect(r!.digit, "the glyph still wears the tray digit").toBe(true)
-  expect(r!.landOpacity, "the landing card stays visible behind the sheet").toBe("1")
+  // PRESENT, BUT STOOD DOWN. Strictly between 0 and 1: `0` would be the v1.135 hide this test was
+  // written to forbid, `1` would be the v1.136 lie where a fully-live-looking card refused A-D.
+  const op = parseFloat(r!.landOpacity!)
+  expect(op, "the landing card is still painted behind the sheet").toBeGreaterThan(0)
+  expect(op, "...but dimmed, so it cannot read as the live surface").toBeLessThan(1)
   expect(r!.landVisibility).toBe("visible")
+  expect(r!.landMarked, "and it carries the stand-down marker").toBe(true)
+  expect(r!.kidCount, "a card with content to disarm").toBeGreaterThan(0)
+  expect(r!.kidsInert, "its children are inert — no clicks, no tab stops, no a11y tree").toBe(true)
+  expect(r!.landRootInert, "the root is NOT inert: it must still swallow the tap").toBe(false)
   expect(r!.sheetOverLand, "and the sheet stacks over it").toBe(true)
+
+  // THE KEYBOARD AGREES WITH THE PAINT. A dimmed card must not grade — this is the assertion that
+  // gates `_detailCtx`'s membership in `_landHidden()` from the mouse side of the app.
+  const answeredWhileOpen = (await j.beats()).filter((b) => b.beat === "land_q_answered").length
+  await page.keyboard.press("a")
+  await j.advance(200)
+  expect(
+    (await j.beats()).filter((b) => b.beat === "land_q_answered").length,
+    "A-D does not grade the card standing behind the sheet",
+  ).toBe(answeredWhileOpen)
+
+  // ...AND IT ALL COMES BACK. The restore is flag-synchronous (`_landHidden` asks the holders, not
+  // the pixels), so the card is live again the instant the sheet closes.
+  await page.keyboard.press("Escape")
+  await j.advance(400)
+  await page.waitForTimeout(400) // the .22s dim transition is wall-clock, like the entry animation
+  const back = await page.evaluate(() => {
+    const a: any = (window as any).__neural
+    const land = a._landEl
+    return {
+      opacity: land ? getComputedStyle(land).opacity : null,
+      marked: land ? land.hasAttribute("data-behind-sheet") : null,
+      kidsInert: land ? [...land.children].some((c: any) => c.inert === true) : null,
+      ctx: !!a._detailCtx,
+    }
+  })
+  expect(back!.ctx, "Esc closed the sheet").toBe(false)
+  expect(back!.opacity, "the card is at full strength again").toBe("1")
+  expect(back!.marked, "the marker is gone").toBe(false)
+  expect(back!.kidsInert, "and nothing is left inert").toBe(false)
+})
+
+/**
+ * A REAL MOUSE ON THE STOOD-DOWN CARD DOES NOTHING — AND "NOTHING" IS TWO CLAIMS (v1.137.0).
+ *
+ * The card behind the sheet must neither GRADE (its buttons are inert) nor be DESTROYED. The
+ * second half is the one that is easy to get wrong: `attachInput`'s pointerdown early-return is a
+ * TARGET test (`ov.contains(e.target)`), so the obvious implementations — `pointer-events:none` on
+ * the card root, or `inert` on the root — make the tap miss the card entirely and land on the
+ * canvas, where `_tapBackground()` declines the question and clears the card while the sheet is
+ * still open. That kills the pinned "back out of a sheet and the question still pays" contract
+ * from a direction no keyboard test can see. Hence: children inert, root left hit-testable.
+ *
+ * `locator.click()` cannot make this claim (§6.3) — it dispatches ON the element. This uses
+ * page.mouse at a MEASURED point, which is the only thing that exercises the real hit test.
+ *
+ * Mutants that must die: dropping `inert` from `_syncDetailDim` (the click grades); moving `inert`
+ * to the card root, or setting pointer-events:none on it (the click destroys the card).
+ */
+test("a real click on the card behind the sheet neither answers it nor destroys it", async ({
+  page,
+}) => {
+  const j = journey(page)
+  await j.boot("/")
+  await j.land("Mount Top")
+  const mc = await j.landQuestion()
+  expect(mc, "a live landing question to stand down").toBeTruthy()
+
+  await page.keyboard.press("1") // digit opens the first option's sheet
+  await expect(page.locator("[data-go]"), "digit 1 opened an option sheet").toBeVisible()
+  await j.advance(300)
+  await page.waitForTimeout(400)
+
+  // Find a point that is inside the card and NOT under the sheet. Measured, never assumed: the
+  // sheet is bottom-anchored and the card's exposed strip shrinks as the sheet grows.
+  const pt = await page.evaluate(() => {
+    const a: any = (window as any).__neural
+    const land = a._landEl, panel = a.optDetailRef.current
+    if (!land || !panel) return null
+    const cr = land.getBoundingClientRect(), pr = panel.getBoundingClientRect()
+    const y = Math.min(cr.bottom, pr.top) - 6 // just above the sheet's top edge, inside the card
+    if (y <= cr.top + 2) return null          // no exposed strip at this viewport
+    const x = cr.left + cr.width / 2
+    const hit = document.elementFromPoint(x, y)
+    return { x, y, insideCard: !!(hit && land.contains(hit)), hitTag: hit ? hit.tagName : null }
+  })
+  // POSITIVE COVERAGE (§6.6): if the strip is not there, this test proves nothing and must say so
+  // rather than passing quietly on a click into empty space.
+  expect(pt, "the card has a strip exposed above the sheet to click on").toBeTruthy()
+  expect(
+    pt!.insideCard,
+    `the measured point resolves into the card, not ${pt!.hitTag} — the root must stay hit-testable`,
+  ).toBe(true)
+
+  const before = await j.beats()
+  await page.mouse.click(pt!.x, pt!.y)
+  await j.advance(400)
+  const after = await j.beats()
+  const fired = (name: string) =>
+    after.filter((b) => b.beat === name).length - before.filter((b) => b.beat === name).length
+
+  expect(fired("land_q_answered"), "the click did not grade the stood-down question").toBe(0)
+  const state = await page.evaluate(() => {
+    const a: any = (window as any).__neural
+    return { card: !!a._landEl, ctx: !!a._detailCtx, mc: !!a._mc }
+  })
+  expect(state!.card, "the card survived the click").toBe(true)
+  expect(state!.ctx, "and the sheet is still open").toBe(true)
+  expect(state!.mc, "and the question is still there to come back to").toBe(true)
+
+  // THE REFUSAL IS IN THE MODEL, NOT ONLY IN THE CSS. `_mc.answer(i)` is the seam BOTH input paths
+  // call — `_onKey` invokes it for A-D, and every option button's click listener is a closure over
+  // the same function — so driving it is driving the real entry point, not a second implementation
+  // of it (§6.3). Without this, `inert` alone hides the grading path from every spec and the
+  // model-level guard has no gate: mutating it away left the whole suite green.
+  const beforeSeam = (await j.beats()).filter((b) => b.beat === "land_q_answered").length
+  await page.evaluate(() => {
+    const a: any = (window as any).__neural
+    if (a._mc && a._mc.answer) a._mc.answer(a._mc.correct)
+  })
+  await j.advance(300)
+  expect(
+    (await j.beats()).filter((b) => b.beat === "land_q_answered").length,
+    "the answer seam itself refuses while the card is stood down",
+  ).toBe(beforeSeam)
+
+  // the contract the swallow protects: back out, and the question still pays
+  await page.keyboard.press("Escape")
+  await j.advance(300)
+  await page.keyboard.press("abcd"[mc!.correct])
+  await j.advance(300)
+  const paid = (await j.beats()).filter((b) => b.beat === "land_q_answered")
+  expect(paid.length, "after Esc the question answers normally").toBe(1)
+  expect((paid[0] as any).correct).toBe(true)
 })

--- a/neural/src/app.src.jsx
+++ b/neural/src/app.src.jsx
@@ -507,7 +507,7 @@ class Component extends DCLogic {
     }
     // modal: card blocks pan + wheel; backdrop click closes
     if (this.modalCardRef.current) { this.modalCardRef.current.addEventListener("pointerdown", (e) => e.stopPropagation()); this.modalCardRef.current.addEventListener("wheel", (e) => e.stopPropagation(), { passive: false }); }
-    if (this.modalRef.current) this.modalRef.current.addEventListener("pointerdown", (e) => { e.stopPropagation(); this._detailCtx = null; this.setPaused(false); this.closeModal(); });
+    if (this.modalRef.current) this.modalRef.current.addEventListener("pointerdown", (e) => { e.stopPropagation(); this._setDetailCtx(null); this.setPaused(false); this.closeModal(); });
     // Z LADDER (v1.95.1, see helmet.html): the modal is a DELIBERATE screen — portal it out
     // of the wrap (whose stacking context traps any z it wears) onto the root overlay plane,
     // where its 95 outranks every ambient overlay (landcard 5, combo pop 72).
@@ -3636,7 +3636,7 @@ class Component extends DCLogic {
       if (bedit) bedit.addEventListener("click", (e) => { e.stopPropagation(); bedit.style.display = "none"; if (bsteps) { bsteps.style.display = "flex"; requestAnimationFrame(() => bsteps.style.opacity = "1"); } });
       if (bdn) bdn.addEventListener("click", (e) => { e.stopPropagation(); this.bumpCardSuccess(n, -1); bupd(); });
       if (bup) bup.addEventListener("click", (e) => { e.stopPropagation(); this.bumpCardSuccess(n, 1); bupd(); }); }
-    go.addEventListener("click", () => { this._detailCtx = null; this.hideOptDetail(); this.setPaused(false); onPick(opt); });
+    go.addEventListener("click", () => { this._setDetailCtx(null); this.hideOptDetail(); this.setPaused(false); onPick(opt); });
     // the two actions lifted out of the head (v1.102.1) land here, on their own row above the
     // primary pair — grouped with the other things you can DO, not stacked over the name
     if (hasPersp || true) {
@@ -3663,7 +3663,7 @@ class Component extends DCLogic {
     panel.appendChild(foot);
     // beat beacon hands into the sheet: the drill first (odds are pumpable) — else straight to Execute
     { const jitEl = panel.querySelector("[data-jit]"); this.setBeacon(jitEl ? "jit" : "execute", jitEl || go); }
-    this._detailCtx = { opt: opt, onPick: onPick };
+    this._setDetailCtx({ opt: opt, onPick: onPick });   // ...and the card behind it stands down (see _syncDetailDim)
 
     // expand / collapse the sheet (compact peek -> full)
     this._optExpanded = false;
@@ -3818,7 +3818,7 @@ class Component extends DCLogic {
     // the animated collapse below (the normal ✕ / back path, taken whenever _optStart is set)
     // never called it, so peeking at an option and backing out left the card that says where you
     // are invisible for the rest of the turn. Found by the late-payload journey.
-    this._detailCtx = null;
+    this._setDetailCtx(null);
     if (this._optPick && this._defendSub == null && this.optionsRef.current) this.setBeacon("options", this.optionsRef.current); // back to the hand
     this.clearClipLoops();
     clearTimeout(this._optSettle);
@@ -7481,6 +7481,68 @@ class Component extends DCLogic {
       else { t.style.removeProperty("opacity"); t.style.pointerEvents = ""; t.style.removeProperty("visibility"); }
     }
   }
+  /**
+   * THE CARD STANDS DOWN WHILE THE OPTION SHEET OWNS THE SCREEN (v1.137.0).
+   *
+   * v1.136.0 stopped HIDING the landing card on `expandOption` — the owner's call was that the
+   * sheet maximizes IN FRONT of it, not that the card vanishes — but it left `_detailCtx` in
+   * `_landHidden()`'s holder list. So the app believed the card was hidden while the card painted
+   * at full strength, and the two input paths disagreed about a surface the player was looking at:
+   * A-D refused to grade (the gate in `_onKey` asks `_landHidden()`), while a mouse click on the
+   * strip peeking above the sheet still graded, because `_declineLandQ("sheet")` sets neither
+   * `truth.spent` nor `rec.revealed` (deliberately: a declined question still pays if you back out
+   * and answer it). "Looks active, won't answer."
+   *
+   * The card now READS as what it already was: dimmed, and dead to every input path.
+   *
+   * WHY THE ROOT STAYS HIT-TESTABLE, AND ONLY THE CHILDREN GO `inert`. `attachInput`'s pointerdown
+   * early-return is a TARGET test (`ov.contains(e.target)`), so anything that makes the card root
+   * hit-test-transparent — `pointer-events:none` on the root, or `inert` on the root — drops
+   * `e.target` through to the canvas, where the tap reaches `_tapBackground()`: it declines the
+   * question and DESTROYS the card without closing the sheet, which would break the very
+   * answer-after-Esc contract this surface exists to keep. With the root left alone, the existing
+   * early-return keeps absorbing the tap and no geometry code is needed in §6.1's most dangerous,
+   * hand-maintained list. `inert` on the children is what actually disarms them: it is the only
+   * primitive a descendant cannot re-enable inline, which matters because `[data-land-foot]` does
+   * exactly that with `pointer-events` on purpose, and it takes focus and the a11y tree with it.
+   *
+   * The dim itself is a STYLESHEET rule keyed on `data-behind-sheet` (helmet.html), not an inline
+   * style: stylesheet `!important` outranks the running `ngCardInX` entry animation, so a card
+   * BORN under an open sheet is born dimmed; and it cannot collide with `_suppressLand`, which
+   * writes and removes INLINE important opacity/visibility when a pane genuinely hides the card.
+   * Its values sit one step short of the app's decay grammar (`ngDeckExpire` ends at grayscale(1)
+   * brightness(.5) opacity .34): dimmer than live, not as dead as expired. The transition is on the
+   * dim only — removing the attribute snaps the card back, matching the flag-synchronous instant
+   * the keys come alive again, because `_landHidden()` asks the holders and never the pixels.
+   *
+   * KEEP THE PROSE ON THIS SIDE. §6.9's "comments are stripped by the build, so documentation is
+   * free" is true of THIS file and false of helmet.html: its CSS comments ship to every visitor.
+   * Measured on the first cut of this change — the rule's 10-line comment cost ~800 payload bytes
+   * against 367 for all of the code, and put `payload-first-hand` 304 bytes over its gzip ceiling.
+   *
+   * DERIVED, NEVER LATCHED (§6.5). The state is `!!this._detailCtx` and nothing else, because that
+   * flag has SEVEN writers and a latch would drift the first time one of them was missed. Every
+   * runtime writer goes through `_setDetailCtx`; the constructor's field init is the only bare
+   * assignment left. `renderLandCard` calls this unconditionally so a rebuilt card re-derives.
+   *
+   * Not observable by any spec, and recorded rather than fixed: the Execute/Go door syncs on its
+   * way out, but that interaction destroys the card in the same beat, so no assertion can see it.
+   * UNGUARDED: the `_landFilmEl` half. The DSL serves {} for dossier chunks, so no film ever mounts
+   * under the harness (§6.4) — it ships on the shared code path, checked by hand only.
+   */
+  _syncDetailDim() {
+    const on = !!this._detailCtx;
+    for (const t of [this._landEl, this._landFilmEl]) {
+      if (!t) continue;
+      if (on) t.setAttribute("data-behind-sheet", "1"); else t.removeAttribute("data-behind-sheet");
+      for (const c of t.children) c.inert = on;
+    }
+  }
+  /** The one writer of `_detailCtx` (§6.5): every set and every null goes through here, so the
+   *  card's stand-down can never drift from whether a sheet is actually open. Lifters, i.e. every
+   *  site that hands the card back: `closeOptionDetail` (Back / ✕ / Esc / Enter-commit), the
+   *  Execute door, the modal backdrop, both `confirmPlayFrom` exits, and `clearOptions`. */
+  _setDetailCtx(ctx) { this._detailCtx = ctx || null; this._syncDetailDim(); }
   // role badge colored by the advantage the seat gives you (app's dominance model): blue = ahead, red = behind
   badgePill(b, fs, pad) {
     if (!b) return "";
@@ -7888,7 +7950,7 @@ class Component extends DCLogic {
     // Z LADDER (helmet.html): a confirm is a DELIBERATE screen — host it on the root overlay
     // plane at the modal band (95), not inside the wrap where the landing card (z:5, root
     // plane) would paint over it and its z:40 could never win.
-    const host = this.__ngRoot || this.wrapRef.current; if (!host) { this._detailCtx = null; this.hideOptDetail(); this.playFrom(seedIdx, role); return; }
+    const host = this.__ngRoot || this.wrapRef.current; if (!host) { this._setDetailCtx(null); this.hideOptDetail(); this.playFrom(seedIdx, role); return; }
     const ov = document.createElement("div");
     ov.style.cssText = "position:fixed;inset:0;z-index:95;display:flex;align-items:center;justify-content:center;background:rgba(8,11,18,.62);backdrop-filter:blur(3px);pointer-events:auto;";
     const close = () => { ov.style.opacity = "0"; setTimeout(() => ov.remove(), 160); };
@@ -7907,7 +7969,7 @@ class Component extends DCLogic {
     ov.querySelector(".ng-cf-no").addEventListener("click", close);
     ov.querySelector(".ng-cf-yes").addEventListener("click", () => {
       close();
-      this._detailCtx = null; this.hideOptDetail();
+      this._setDetailCtx(null); this.hideOptDetail();
       this._openSidebarOnLand = true;     // land back in the flashcards home on the seeded state
       // THE ACTION IS THE CALLER'S WHEN IT NEEDS ITS OWN (v1.106.5): the SCREEN is shared — one
       // copy of the wording, one z:95 host, one place that asks before a live roll is discarded —
@@ -8265,7 +8327,14 @@ class Component extends DCLogic {
         btns[i].style.background = "rgba(255,110,110,.07)";
       }
     };
-    const answer = (i) => { if (answered || truth.spent) { explore(i); return; } answered = true; this._mcAnswer(i, card, key, wrap, live, onDone, truth); };
+    // ONE PREDICATE GOVERNS BOTH INPUT PATHS (v1.137.0). The A-D gate in `_onKey` already refuses
+    // to grade a landing question while `_landHidden()` holds — "A-D must not grade a question
+    // nobody can see" — but the mouse had no such rule, so with the option sheet open the keyboard
+    // refused while a click on the strip peeking above the sheet still graded. `_landHidden()` is
+    // the flag-derived truth (never the pixels), so the refusal flips back the instant the sheet
+    // closes, with no transition to race. Not a decline and not a grade: the question is untouched
+    // and still pays when the player comes back to it.
+    const answer = (i) => { if (truth.surface === "land" && this._landHidden()) return; if (answered || truth.spent) { explore(i); return; } answered = true; this._mcAnswer(i, card, key, wrap, live, onDone, truth); };
     truth.answer = answer;                                    // the A/B/C/D keyboard seam
     mc.options.forEach((o, i) => {
       const b = document.createElement("button");
@@ -8740,7 +8809,7 @@ class Component extends DCLogic {
   clearOptions() {
     // any commit/teardown consumes a staged exchange (rollFromPosition sets it AFTER this runs)
     this._stagedTech = null;
-    const el = this.optionsRef.current; if (el) { el.innerHTML = ""; el.style.pointerEvents = "none"; el.style.opacity = "1"; el.style.transform = "none"; el.style.overflowX = "auto"; el.style.overflowY = "hidden"; el.style.webkitMaskImage = ""; el.style.maskImage = ""; el.style.justifyContent = "safe center"; el.style.paddingLeft = ""; el.style.paddingRight = ""; el.scrollLeft = 0; } this._trayStop(); this._detailCtx = null; this.hideOptDetail(); this.clearLandCard(); this.optionIdxs = []; this._optionCards = []; this._optHintAt = 0; this.setBeacon(null); this._dropCountdownEvent(); }
+    const el = this.optionsRef.current; if (el) { el.innerHTML = ""; el.style.pointerEvents = "none"; el.style.opacity = "1"; el.style.transform = "none"; el.style.overflowX = "auto"; el.style.overflowY = "hidden"; el.style.webkitMaskImage = ""; el.style.maskImage = ""; el.style.justifyContent = "safe center"; el.style.paddingLeft = ""; el.style.paddingRight = ""; el.scrollLeft = 0; } this._trayStop(); this._setDetailCtx(null); this.hideOptDetail(); this.clearLandCard(); this.optionIdxs = []; this._optionCards = []; this._optHintAt = 0; this.setBeacon(null); this._dropCountdownEvent(); }
   // "Decide 1…" IS THE HAND'S SENTENCE, so it cannot outlive the hand. Clicking another node mid
   // countdown stages a fresh board — clock held, bars back to full — and the owner met the old
   // window's last warning still on screen over it. `enterLand` already drops a stale announcer,
@@ -10002,6 +10071,11 @@ class Component extends DCLogic {
     this._dockLandCard(el);
     // a fresh card born while the reading sheet owns the screen must not pop over it
     if (this._traySup || this._dossierIdx != null) this._suppressLand(true);
+    // ...and one born under an OPEN OPTION SHEET is born stood down. Unconditional on purpose: it
+    // derives from `_detailCtx` and is a no-op when no sheet is open, so it cannot rot the way a
+    // second copy of the condition above would. A backfill builds a brand-new element with fresh,
+    // non-inert children, so this is the only thing that re-applies the dim to it.
+    this._syncDetailDim();
     return el;
   }
   /**

--- a/neural/src/helmet.html
+++ b/neural/src/helmet.html
@@ -212,6 +212,8 @@
   .ng-replaybar .ng-replay-stop:focus-visible{outline:2px solid rgba(160,185,255,.85);outline-offset:-3px;}
   /* the panic drill wears the danger skin, but is a landing card in every other respect */
   .ng-landcard[data-landcard="defense"]{border-color:rgba(255,110,110,.42);background:linear-gradient(180deg,rgba(52,22,24,.97),rgba(38,16,18,.97));}
+  /* stood down behind the option sheet — why it is a rule and not an inline style: _syncDetailDim */
+  [data-behind-sheet]{opacity:.38!important;filter:grayscale(.7) brightness(.8);transition:opacity .22s ease,filter .22s ease;}
   /* ── MOMENTUM: the arcade announcer + the heat chip. Heat 1→5 = ×2→×6+. ── */
   .ng-combo-pop{position:fixed;left:50%;top:31%;transform:translate(-50%,-50%);z-index:72;pointer-events:none;text-align:center;font-family:'Space Grotesk',sans-serif;animation:ngComboPop 1.15s cubic-bezier(.2,.7,.2,1) both;}
   .ng-combo-pop .ng-combo-x{font-size:12px;font-weight:800;letter-spacing:.34em;text-transform:uppercase;color:#9ab0e0;margin-bottom:4px;}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bjjgraph",
-  "version": "1.137.0",
+  "version": "1.137.1",
   "description": "BJJ knowledge graph and state machine",
   "scripts": {
     "postinstall": "cd source && npm install",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bjjgraph",
-  "version": "1.136.0",
+  "version": "1.137.0",
   "description": "BJJ knowledge graph and state machine",
   "scripts": {
     "postinstall": "cd source && npm install",

--- a/tests/artifacts/first_hand_payload.json
+++ b/tests/artifacts/first_hand_payload.json
@@ -1,11 +1,11 @@
 {
  "_meta": {
   "note": "Written by e2e/journeys/payload-first-hand.spec.ts. Observed only — the ceilings live in budget_neural.json.",
-  "measured_at": "2026-08-26T11:30:11.622Z"
+  "measured_at": "2026-08-26T16:05:39.244Z"
  },
  "request_count": 20,
- "first_hand_raw_bytes": 1693165,
- "first_hand_gzip_bytes": 384865,
+ "first_hand_raw_bytes": 1693607,
+ "first_hand_gzip_bytes": 384956,
  "start_position": "Gogoplata Control Top",
  "charged_from_disk": [],
  "heaviest": [
@@ -16,8 +16,8 @@
   },
   {
    "path": "/static/neural/app/neural.js",
-   "raw": 475070,
-   "gzip": 141366
+   "raw": 475437,
+   "gzip": 141478
   },
   {
    "path": "/static/neural/flashcards/_index.json",
@@ -31,13 +31,13 @@
   },
   {
    "path": "/postscript.js",
-   "raw": 78046,
-   "gzip": 28668
+   "raw": 77889,
+   "gzip": 28562
   },
   {
    "path": "/static/neural/app/neural.css",
-   "raw": 57927,
-   "gzip": 15883
+   "raw": 58159,
+   "gzip": 15968
   },
   {
    "path": "/index.css",


### PR DESCRIPTION
## The bug

Opening an option/transition detail sheet left the landing quiz card painted at full strength underneath it — looking like the live surface while refusing to answer.

v1.136.0 stopped *hiding* the card on expand (your call: the sheet maximizes **in front** of it, it does not make the card vanish) but left `_detailCtx` in `_landHidden()`'s holder list. So the app believed the card was hidden while it painted at full strength, and the two input paths disagreed about a card you were looking at:

- **A–D refused to grade** — the answer gate asks `_landHidden()`, and `_detailCtx` makes it true.
- **The mouse still graded**, on the strip peeking above the sheet, because `_declineLandQ("sheet")` sets neither `truth.spent` nor `rec.revealed` — deliberately, since a declined question still pays if you back out and answer it.
- **Nothing dimmed it**, so it read as live.

## The fix

The card now reads as what it already was: **dimmed and fully stood down**, restored on Esc/Back/✕.

- Dimmed by a `data-behind-sheet` stylesheet rule (`opacity .38` + slight grayscale — the app's `ngDeckExpire` decay grammar, held one step short of expired). Tune the numbers freely; the gate only asserts `0 < opacity < 1`.
- Dead to every input path: children `inert` (no clicks, no tab stops, no a11y tree), and the `_mc.answer` seam itself refuses while `_landHidden()` holds — so **one predicate governs both the mouse and the keyboard** instead of two mechanisms disagreeing.

### Why the root stays hit-testable

`attachInput`'s pointerdown early-return is a **target** test (`ov.contains(e.target)`). So `pointer-events:none` or `inert` **on the root** would drop the tap through to the canvas, where `_tapBackground()` declines the question and **destroys the card with the sheet still open** — breaking the answer-after-Esc contract from a direction no keyboard test can see. Children-only `inert` keeps the existing early-return swallowing the tap, and §6.1's hand-maintained overlay list needed no edit at all.

### State discipline

Derived, never latched (§6.5): `_setDetailCtx` is now the one writer of `_detailCtx`. All seven runtime sites route through it — including both `confirmPlayFrom` exits and the Execute door, which the first survey missed — and `renderLandCard` re-derives unconditionally, so a backfilled card is born stood down.

## Gated by mutation (§8)

Eight mutants, eight kills: `_syncDetailDim` no-oping · `closeOptionDetail` reverting to a bare null · deleting the `renderLandCard` re-assert · removing `_detailCtx` from `_landHidden()` · deleting the helmet rule · dropping `inert` · moving `inert` to the root · dropping the `answer()` guard.

That last one **survived the first pass** — `inert` hides the grading path from every spec, so the model-level guard had no gate. The tap-swallow journey now drives `_mc.answer()` directly, the seam both input paths share; it goes red without the guard.

`option-edge`'s `@curated` landcard claim changes from "opacity is exactly 1" to "dimmed, present, inert". The original "re-hiding the landcard on expand" mutant still dies, on `> 0` and `visibility: visible`.

**Recorded, not gated:** the Execute door's sync (that interaction destroys the card in the same beat, so no assertion can see it) and the `_landFilmEl` half (the DSL serves `{}` for dossier chunks, so no film ever mounts under the harness — §6.4). Both are written at the definition.

## Payload note

§6.9's "comments are stripped by the build" is true of `app.src.jsx` and **false of `helmet.html`** — its CSS comments ship to every visitor. The rule's first 10-line comment cost ~800 bytes against 367 for all of the code, and put `payload-first-hand` 304 bytes over its gzip ceiling. The prose moved to the JS side, where it is free.

First-hand gzip now measures **384,956 against a 385,000 ceiling — 44 bytes of headroom.** Worth knowing before the next change.

## Verification

`193/193 @curated` green, plus `option-edge`, `keyboard`, `coldstart-backfill`, `landing-card`, `landcard-modes`, `lists-picker` all green.

Worth a look yourself: `npm run dev:neural:app && npm run serve`, open a position, press `1` over a live question, and confirm the card behind recedes and ignores clicks, A–D and Tab — then Esc and confirm it snaps back and the correct letter still scores.

## Conflict note

The in-flight `fix/clock-engagement-gate` work in your main checkout also claims v1.137.0 and adds a third `_landHidden()` consumer. No semantic conflict — `_declineLandQ("sheet")` disarms the clock before any arm — but whichever lands second re-bumps its version and re-checks that consumer list. Both branches also touch `tests/artifacts/first_hand_payload.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLU7pU692LdGPws3Z91niL