### PR TITLE
v1.136.2 - The refs gate stopped failing on the files it knows are generated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bjjgraph",
-  "version": "1.136.0",
+  "version": "1.136.2",
   "description": "BJJ knowledge graph and state machine",
   "scripts": {
     "postinstall": "cd source && npm install",

--- a/scripts/check_claudemd_refs.py
+++ b/scripts/check_claudemd_refs.py
@@ -13,6 +13,11 @@ would act on:
   1. REPO PATHS in backticks (anything containing a `/` or ending in a known source
      extension). A path that no longer resolves sends a reader — or an agent — hunting
      through a tree for a file that was renamed or deleted.
+     A path that is absent but GITIGNORED is not that: it is a generated artifact the canon
+     names on purpose (`source/public`, the emitted neural payload, the dev snapshot dump).
+     Those resolve in the tree a human works in and never in a fresh checkout, so demanding
+     they exist made this gate fail for everyone EXCEPT the person who had just built. See
+     `_git_ignored` for why the answer is git rather than another hand-kept list.
   2. `npm run <script>` invocations, against the real scripts in package.json. A documented
      command that does not exist is worse than an undocumented one: it looks authoritative
      and fails at the shell.
@@ -34,6 +39,7 @@ Deliberately stdlib-only.
 
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -58,6 +64,10 @@ ALLOW_ABSENT = {
     "l.html", "l-manifest.json", "sitemap.xml", "llms.txt", "neural.js", "neural.css",
     "graph-data.json", "sound-catalog.json", "questionBank.json", "graphAdjacency.json",
     "postscript.js", "prescript.js", "index.css", "globalGraphLayout.json",
+    # ...also emitted by regenerate:neural, beside graph-data.json above. A BARE filename
+    # cannot be answered by `_git_ignored` (there is no path to test a rule against), so
+    # emitted files named without their directory still belong on this list.
+    "systems.json",
     # deleted on purpose (v1.80.0 legacy excision, v1.126.0 prototype retirement)
     "trainingSession.ts", "srs.ts", "settings.ts", "explored.ts", "known.ts",
     "dateUtil.ts", "gameAudio.ts", "explorerGraphExpand.ts", "Graph.tsx",
@@ -83,6 +93,57 @@ def _index_basenames() -> dict:
     return idx
 
 
+_IGNORE_CACHE: dict[str, bool] = {}
+_GIT_OK = True
+
+
+def _git_ignored(tok: str) -> bool:
+    """Is this absent path one git is deliberately not tracking?
+
+    DERIVED, NOT LISTED. The alternative was another hand-kept allow-list, and §6.7's trap
+    is exactly that: a hand-maintained enumeration is missing its newest member by default.
+    Git already knows which paths are generated — .gitignore is the declaration — so ask it.
+
+    TRAILING SLASH IS LOAD-BEARING. A dir-only rule (`source/public/`) does not match the
+    path `source/public`, because for a path that does not exist git cannot know it is a
+    directory: measured, `source/public` reads NOT ignored and `source/public/` reads
+    ignored, against the same rule. Both spellings are tested, which is what lets the canon
+    write the natural `source/public` in prose.
+
+    This cannot launder a typo. A misspelled directory (`tests/artifacts/snapshotz/`) matches
+    no rule and still fails; only a name INSIDE an ignored directory is waved through, and
+    the contents of a generated directory are not knowable from a clean tree anyway.
+
+    If git cannot answer at all, the honest failure is the STRICT one: return False so the
+    reference is reported, rather than silently passing every dangling path in the file.
+    """
+    global _GIT_OK
+    if tok in _IGNORE_CACHE:
+        return _IGNORE_CACHE[tok]
+    result = False
+    if _GIT_OK:
+        for cand in (tok, tok.rstrip("/") + "/"):
+            try:
+                p = subprocess.run(["git", "check-ignore", "-q", "--", cand],
+                                   cwd=ROOT, capture_output=True, timeout=10)
+            except (OSError, subprocess.SubprocessError):
+                _GIT_OK = False
+                print("[check_claudemd_refs] WARNING: `git check-ignore` unavailable — "
+                      "generated paths cannot be distinguished from dangling ones, so "
+                      "every absent path below is reported strictly", file=sys.stderr)
+                break
+            if p.returncode == 0:
+                result = True
+                break
+            if p.returncode not in (0, 1):   # 128 = not a repo, bad args
+                _GIT_OK = False
+                print(f"[check_claudemd_refs] WARNING: `git check-ignore` returned "
+                      f"{p.returncode} — falling back to strict absence checks", file=sys.stderr)
+                break
+    _IGNORE_CACHE[tok] = result
+    return result
+
+
 def path_candidates(text: str):
     """Yields (token, offset, kind). kind is 'path' (contains a separator, must resolve
     exactly) or 'name' (a bare filename, must exist somewhere in the tree)."""
@@ -106,16 +167,21 @@ def line_of(text: str, off: int) -> int:
     return text.count("\n", 0, off) + 1
 
 
-def check(doc: Path) -> tuple[list[str], dict]:
+def check(doc: Path, generated: set) -> tuple[list[str], dict]:
     text = doc.read_text(encoding="utf-8")
-    errors, counts = [], {"paths": 0, "npm": 0, "cites": 0}
+    errors, counts = [], {"paths": 0, "npm": 0, "cites": 0, "generated": 0}
 
     names = _index_basenames()
     for tok, off, kind in path_candidates(text):
         counts["paths"] += 1
         if kind == "path":
             if not (ROOT / tok).exists() and Path(tok).name not in ALLOW_ABSENT:
-                errors.append(f"{doc.name}:{line_of(text, off)} dangling path `{tok}`")
+                # absent AND gitignored = a generated artifact, named on purpose
+                if _git_ignored(tok):
+                    counts["generated"] += 1
+                    generated.add(tok)
+                else:
+                    errors.append(f"{doc.name}:{line_of(text, off)} dangling path `{tok}`")
         elif tok not in names and tok not in ALLOW_ABSENT:
             errors.append(
                 f"{doc.name}:{line_of(text, off)} names `{tok}`, which exists nowhere "
@@ -153,18 +219,19 @@ def check(doc: Path) -> tuple[list[str], dict]:
 
 def main() -> None:
     docs = [Path(a) for a in sys.argv[1:]] or [ROOT / "CLAUDE.md"]
-    all_errors, total = [], {"paths": 0, "npm": 0, "cites": 0}
+    all_errors, total = [], {"paths": 0, "npm": 0, "cites": 0, "generated": 0}
+    generated: set = set()
     for d in docs:
         d = d if d.is_absolute() else ROOT / d
         if not d.exists():
             all_errors.append(f"{d}: does not exist")
             continue
-        errs, counts = check(d)
+        errs, counts = check(d, generated)
         all_errors += errs
         for k in total:
             total[k] += counts[k]
 
-    checked = sum(total.values())
+    checked = total["paths"] + total["npm"] + total["cites"]
     if all_errors:
         print("[check_claudemd_refs] FAILED", file=sys.stderr)
         for e in all_errors:
@@ -178,6 +245,11 @@ def main() -> None:
     print(f"[check_claudemd_refs] OK — {total['paths']} repo paths, "
           f"{total['npm']} npm scripts, {total['cites']} symbol@line citations, "
           f"all resolve ({', '.join(d.name for d in docs)})")
+    # THE SKIP PRINTS (§6.6). A reference waved through as "generated" is one this gate did
+    # not actually verify, so it is named every run: a list that grows is a list to read.
+    if generated:
+        print(f"    {total['generated']} reference(s) to {len(generated)} absent-but-gitignored "
+              f"path(s), generated and therefore NOT verified: {', '.join(sorted(generated))}")
 
 
 if __name__ == "__main__":

--- a/tests/claudemd_refs_gate.test.mjs
+++ b/tests/claudemd_refs_gate.test.mjs
@@ -1,0 +1,69 @@
+// Pure-unit suite for the CLAUDE.md reference gate itself:
+//   node --test tests/claudemd_refs_gate.test.mjs
+//
+// WHAT THIS IS FOR. `check_claudemd_refs.py` runs in ci-validate as the FOURTH step of a job
+// whose remaining gates — the share-ordinal lockfile, MC viability, graph integrity — run
+// after it and are SKIPPED when it exits non-zero. So a false failure here does not merely
+// annoy: it silently stops three hard gates from running at all, and the job's red X looks
+// like one problem while hiding three unknowns.
+//
+// That is exactly what happened before v1.136.2. The gate demanded that every backticked path
+// exist, and the canon legitimately names four GENERATED ones (`source/public`, the emitted
+// neural payload, the dev snapshot dump). Those exist for anyone who has just built and never
+// in a fresh checkout — so the gate passed locally, failed in CI, and had been red on `dev`
+// for hours with nobody reading past the first failure.
+//
+// The two tests below are the whole contract, and they pull in opposite directions on purpose:
+// a generated path must NOT fail the gate, and a misspelled one still MUST. A fix for the
+// first that breaks the second turns the gate into a rubber stamp, which is worse than the
+// false failure it replaced.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve, join } from "node:path";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const GATE = resolve(ROOT, "scripts/check_claudemd_refs.py");
+
+/** Drive the REAL script over a throwaway document — never a re-implementation of its rules. */
+function runGate(markdown) {
+  const dir = mkdtempSync(join(tmpdir(), "claudemd-refs-"));
+  const doc = join(dir, "probe.md");
+  try {
+    writeFileSync(doc, markdown);
+    const r = spawnSync("python3", [GATE, doc], { cwd: ROOT, encoding: "utf8" });
+    return { code: r.status, out: `${r.stdout || ""}${r.stderr || ""}` };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("a GENERATED path the canon names on purpose does not fail the gate", () => {
+  // Every one of these is absent from a fresh checkout and gitignored. Before v1.136.2 this
+  // document was three separate CI failures.
+  const r = runGate(
+    "The built site lives in `source/public`, the payload in " +
+      "`source/quartz/static/neural/`, and dev snapshots land in " +
+      "`tests/artifacts/snapshots/`. A real file: `scripts/check_claudemd_refs.py`.\n",
+  );
+  assert.equal(r.code, 0, `generated paths must pass; gate said:\n${r.out}`);
+  // ...AND IT SAYS SO. A waved-through reference is one the gate did not verify, so silence
+  // here would be the same failure class in a new coat (§6.6).
+  assert.match(r.out, /absent-but-gitignored/, "the skip must print what it waved through");
+  assert.match(r.out, /source\/public/, "...naming the paths, so a growing list is readable");
+});
+
+test("...but a misspelled path still fails, generated-looking or not", () => {
+  const r = runGate(
+    "Typo file: `scripts/check_claudemd_refz.py`\n" +
+      "Typo dir under a real one: `tests/artifacts/snapshotz/`\n" +
+      "A module that no longer exists: `source/quartz/components/Gone.tsx`\n",
+  );
+  assert.equal(r.code, 1, `dangling paths must fail; gate said:\n${r.out}`);
+  for (const needle of ["check_claudemd_refz.py", "snapshotz", "Gone.tsx"]) {
+    assert.match(r.out, new RegExp(needle.replace(/[.]/g, "\\.")), `must name ${needle}`);
+  }
+});


### PR DESCRIPTION
## The bug

`ci-validate` has been **red on `dev`** since at least the v1.131.0..v1.136.0 merge. The failing step is *"CLAUDE.md budget + references (gate)"*:

```
CLAUDE.md:251 dangling path `tests/artifacts/snapshots/`
```

`check_claudemd_refs.py` demanded that every backticked path exist. Four of the paths the canon names are **generated** — `source/public`, `source/quartz/static/neural/` and its `app/`, and the gitignored `tests/artifacts/snapshots/` dump. They resolve for anyone who has just built and never in a fresh checkout, so the gate passed locally and failed in CI. In a pristine tree it was **seven** dangling references, not the one you see after a build.

### The part that matters more than the red X

It is the **fourth step of its job**, so the three gates behind it never ran:

| step | on recent dev pushes |
|---|---|
| CLAUDE.md budget + references | ✗ failed |
| Share ordinal lockfile (append-only, hard gate) | – skipped |
| MC viability audit (hard gate) | – skipped |
| Graph integrity (ratchet against baseline) | – skipped |

Four hard gates reported nothing, and the job looked like one problem.

## The fix

Absence is answered by **git**, not by a second hand-kept list — §6.7's trap is exactly the list, and `.gitignore` is already the declaration of what is generated. A path that is absent *and* ignored is a generated artifact; anything else absent is still an error.

**The trailing slash is load-bearing.** A dir-only rule does not match a path without one: measured, `source/public` reads NOT ignored and `source/public/` reads ignored against the same rule — which is precisely why the natural prose spelling was failing. Both spellings are tested.

**It cannot launder a typo.** A misspelled directory (`tests/artifacts/snapshotz/`) matches no rule and still fails; only a name inside an ignored directory is waved through, and the contents of a generated directory are not knowable from a clean tree anyway.

**No silent passes.** If git cannot answer, the fallback is the *strict* branch with a warning — the failure direction, not the convenient one. And the skip **prints** what it waved through (§6.6), so a reference the gate did not verify is named on every run:

```
[check_claudemd_refs] OK — 149 repo paths, 9 npm scripts, 0 symbol@line citations, all resolve
    6 reference(s) to 4 absent-but-gitignored path(s), generated and therefore NOT verified: …
```

`systems.json` joins `ALLOW_ABSENT` beside `graph-data.json`: a bare filename has no path for a rule to match, so emitted files named without their directory still need the list.

## Gated

New `tests/claudemd_refs_gate.test.mjs` (node `--test`, joins the existing "Pure unit suites" step). Its two cases pull in **opposite directions** on purpose — a generated path must not fail, a misspelled one must — because a fix for the first that breaks the second is a rubber stamp, which is worse than the false failure it replaced. It drives the real script over throwaway documents rather than re-implementing its rules (§6.3).

Three mutants, three kills: reverting the fix (test 1 red), waving through every absent path (test 2 red), silencing the skip print (test 1 red).

## Verification

- `validate:claudemd` green on a **pristine** worktree with no build outputs — the CI-like case that was failing.
- Also green against the `fix/sheet-dims-landcard` branch's CLAUDE.md (152 paths), so that PR clears this gate too.
- `77/77` units green.

## Note

Version numbering across my three open PRs (#199 `1.136.1`, #200 `1.137.0`+`1.137.1`, this `1.136.2`) will collide with the in-flight `fix/clock-engagement-gate`, which also claims `1.137.0`. Whichever merges later re-bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLU7pU692LdGPws3Z91niL