### PR TITLE
v1.159.1 - The tqdm fallback degraded the iterator and nothing else, so it only worked where it was not needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bjjgraph",
-  "version": "1.159.0",
+  "version": "1.159.1",
   "description": "BJJ knowledge graph and state machine",
   "scripts": {
     "postinstall": "cd source && npm install",

--- a/scripts/proofread_all_transitions.py
+++ b/scripts/proofread_all_transitions.py
@@ -55,9 +55,50 @@ from _model import model as _model_tier, effort as _model_effort  # single sourc
 
 try:
     from tqdm import tqdm
-except ImportError:  # CI / minimal envs without tqdm — degrade to a plain iterator
-    def tqdm(iterable=None, *args, **kwargs):
-        return iterable if iterable is not None else []
+except ImportError:  # CI / minimal envs without tqdm
+    # ── A DEGRADED PATH HAS TO CARRY THE WHOLE API ITS CALLER USES ────────────────────
+    # This fell back to the bare iterable, which satisfies `for fp in pbar` and NOTHING
+    # else: `main()` then calls `pbar.set_postfix_str(...)` on the first file and
+    # `pbar.close()` at the end, and a list has neither. So the script died with
+    # `AttributeError: 'list' object has no attribute 'set_postfix_str'` in exactly the
+    # environment this branch was written for — ci-validate.yml installs jsonschema and
+    # nothing else, so tqdm is absent there and present on every dev machine that has
+    # ever run the proofreader. tests/proofread_fork_safety.test.mjs 104-108 were red on
+    # dev for that reason alone, and green for everyone who ran them locally.
+    #
+    # Reproduce the CI environment without uninstalling anything:
+    #   mkdir -p /tmp/no-tqdm && echo 'raise ImportError' > /tmp/no-tqdm/tqdm.py
+    #   PYTHONPATH=/tmp/no-tqdm npm run test:units
+    #
+    # The shim mirrors the methods this script actually calls, by name and on purpose —
+    # no catch-all __getattr__, because a typo'd bar method should still fail loudly
+    # under the gate rather than silently no-op. Add a method here when a caller needs
+    # one; do not make it magic.
+    class tqdm:  # noqa: N801 — deliberately shadows the real class's name
+        def __init__(self, iterable=None, *args, **kwargs):
+            self._iterable = [] if iterable is None else iterable
+
+        def __iter__(self):
+            return iter(self._iterable)
+
+        def __len__(self):
+            return len(self._iterable)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self.close()
+            return False
+
+        def set_postfix_str(self, *args, **kwargs):
+            """Display-only on a real bar; nothing to draw without one."""
+
+        def update(self, *args, **kwargs):
+            """Display-only."""
+
+        def close(self):
+            """Display-only."""
 
 # =============================================================================
 # CONSTANTS


### PR DESCRIPTION
`ci-validate` has been red on `dev` for at least five runs — `tests/proofread_fork_safety.test.mjs` reporting **5 failures** (148/153, latterly 163/168). Not flake, not the oracle: the proofreader crashed on its first file in CI, and had done so every time.

```
AttributeError: 'list' object has no attribute 'set_postfix_str'
scripts/proofread_all_transitions.py:1087 in main
```

## The fallback was half a fallback

`except ImportError` degraded `tqdm` to the bare iterable, which satisfies `for fp in pbar` and nothing else. `main()` then calls `pbar.set_postfix_str(...)` on the first file and `pbar.close()` at the end — a list has neither. **Two crash sites**, one of which the traceback never even reached.

## And it only fired where nobody was looking

`ci-validate.yml` installs `jsonschema` and nothing else, so tqdm is **absent there and present on every machine that has ever run the proofreader**. The branch written *for* CI was the branch only CI took, and it was the broken one.

`npm run test:units` is green locally and red in CI — the inverse of the usual staleness trap. It reads as "CI is being weird" rather than as a real defect, which is what kept it alive.

## The shim names its methods on purpose

`set_postfix_str`, `update` and `close` are written out rather than caught by a `__getattr__`, so a typo'd bar method still fails loudly under the gate instead of silently no-opping. The point is a degraded **display**, never a degraded **check**. Add a method when a caller needs one.

## Measured, both directions

CI's environment reproduced rather than assumed:

```bash
mkdir -p /tmp/no-tqdm && echo 'raise ImportError' > /tmp/no-tqdm/tqdm.py
PYTHONPATH=/tmp/no-tqdm npm run test:units
```

| build | tqdm | result |
|---|---|---|
| unpatched (dev tip) | absent — *what CI runs* | **163/168**, failing 119–123 |
| patched | absent | **168/168** |
| patched | present — *dev machine* | **168/168** |

The repro line rides in the code comment, so the next reader can reproduce CI without uninstalling anything. `grep -rn tqdm scripts/*.py` finds no second copy of this pattern.

Found while trying to merge #203, whose only red check was this one, inherited from dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQzUuzmtheLRKzGHG1wmKQ