### PR TITLE
v1.166.0 - The restart becomes a sequence: countdown, one line, the state names itself, hand-off

### DIFF
--- a/e2e/dsl.ts
+++ b/e2e/dsl.ts
@@ -815,8 +815,9 @@ export class Journey {
       if (idx < 0) throw new Error(`position not found: ${pos}`);
       a.rigStart(idx); // test rail: next startRoll begins here (deterministic role=top)
     }, position);
-    // intro (3.2s) + roll-start toast + landing + options dealt — pump until the hand exists
-    for (let i = 0; i < 12; i++) {
+    // intro (3.2s) + the staged arrival (6.2s, v1.168.0: kicker → name → hand-off) + landing +
+    // options dealt — pump until the hand exists
+    for (let i = 0; i < 16; i++) {
       await this.advance(1000);
       const n = await this.page.evaluate(
         () => ((window as W).__neural.optionIdxs || []).length,

--- a/e2e/journeys/announcer-coherence.spec.ts
+++ b/e2e/journeys/announcer-coherence.spec.ts
@@ -256,7 +256,7 @@ test("@curated the clock running out reveals the answer, says so, and steals not
 }) => {
   const j = journey(page);
   await j.boot("/");
-  await j.advance(6000);
+  await j.advance(10200); // intro 3.2s + the staged arrival 6.2s (v1.168.0) + the deal
   await j.engage(); // v1.137.0: the clock waits for the player — this journey plays one
 
   const handBefore = await page.evaluate(() => ((window as any).__neural.optionIdxs || []).length);

--- a/e2e/journeys/coldstart-late-payload.spec.ts
+++ b/e2e/journeys/coldstart-late-payload.spec.ts
@@ -21,9 +21,16 @@ import { journey } from "../dsl";
  * wall-clock assertions: sim time is pumped by the spec, so the ordering is exact on any machine.
  *
  * MIND THE ORIGIN. `afterSim` counts from BOOT, the same origin as the timeline above — so the
- * EIGHTEEN-second silence between the hand and the decks is `afterSim: 25`, and the assertion that
- * pins it measures `releasedAtSim - (sim clock when the hand was dealt)`, not lateness from boot.
- * Declared as 18 and measured from boot, this spec modelled 13 of the 18 seconds it quoted.
+ * silence between the hand and the decks is `afterSim: 25`, and the assertion that pins it
+ * measures `releasedAtSim - (sim clock when the hand was dealt)`, not lateness from boot.
+ * Declared as 18 and measured from boot, this spec once modelled 13 of the 18 seconds it quoted.
+ *
+ * v1.168.0 MOVED ONE OF THE TWO EVENTS. The deck payload's 25.3s is a NETWORK fact and did not
+ * change; the hand is a UI fact and did — the staged arrival deals it at ~10.2s (intro 3.2 +
+ * arrival 6.2 + the deal), where the probe's build dealt at 7.0. The window this spec exists to
+ * pin — the visitor playing their opening decision with no question, no definition, no film —
+ * is therefore now ~15s, and the floor below is 25 − 10.2, minus the 1s the sim pump quantizes
+ * by: 14. A mutant serving the decks instantly still goes red by ~24s.
  */
 
 type Mark = {
@@ -82,7 +89,7 @@ test("cold start: the harness can hold a payload back, and the app plays its fir
   // reached without stubbing anything on the app: the real fetch is simply still in flight.
   const j = journey(page);
   // afterSim is measured from BOOT, the same origin as the measured timeline — so the production skew
-  // (hand @7.0s, decks @25.3s: eighteen seconds of silence between them) is `afterSim: 25`, not 18.
+  // (decks @25.3s from boot; the hand @~10.2s since v1.167.0) is `afterSim: 25`, not the gap.
   // Declared as 18, with the harness dealing this hand at sim 5.0s, it modelled 13 of those 18
   // seconds — which is why the assertion at the bottom measures the gap FROM THE HAND, not from boot.
   await j.boot("/", {
@@ -153,7 +160,7 @@ test("cold start: the harness can hold a payload back, and the app plays its fir
     "the card the visitor is STILL looking at gains its question",
   ).toBe(1);
 
-  // the timeline is the evidence: requested near sim-zero, served ~18 simulated seconds later
+  // the timeline is the evidence: requested near sim-zero, served ~25 simulated seconds later
   const tl = j.payloadTimeline().filter((p) => /flashcards\/_index\.json/.test(p.url));
   expect(tl.length, "the deck payload was requested exactly once").toBe(1);
   expect(
@@ -161,13 +168,14 @@ test("cold start: the harness can hold a payload back, and the app plays its fir
     "asked for during boot, before any sim time was pumped",
   ).toBe(0);
   // THE SKEW IS A GAP BETWEEN TWO EVENTS, so it is measured between them. Asserting only
-  // `releasedAtSim >= 18000` measured lateness from BOOT and quietly counted the ~7 seconds the
+  // `releasedAtSim >= 18000` measured lateness from BOOT and quietly counted the seconds the
   // visitor spent waiting for the hand as part of the silence they endured WITH it.
   expect(
     tl[0].releasedAtSim! - handAtSim,
-    `the decks land at least 18 simulated seconds AFTER the hand was dealt — the production skew ` +
-      `(hand @7.0s, decks @25.3s). hand at ${handAtSim}ms, payload ${JSON.stringify(tl[0])}`,
-  ).toBeGreaterThanOrEqual(18000);
+    `the decks land at least 14 simulated seconds AFTER the hand was dealt — the production skew ` +
+      `(decks @25.3s from boot, hand @~10.2s under the v1.168.0 staged arrival). ` +
+      `hand at ${handAtSim}ms, payload ${JSON.stringify(tl[0])}`,
+  ).toBeGreaterThanOrEqual(14000);
 });
 
 test("cold start: a spine step that arrives too EARLY is stamped out of order", async ({

--- a/e2e/journeys/share-camera.spec.ts
+++ b/e2e/journeys/share-camera.spec.ts
@@ -215,7 +215,14 @@ test("the class a link lit is STILL ON SCREEN seconds after arrival, with the ro
 
   const s = await screen(page);
   expect(s.paused, "premise: the roll is RUNNING (nothing paused it — pane law stands)").toBe(false);
-  expect(s.hand, "premise: a hand is dealt, so the follow-cam has a node it wants").toBeGreaterThan(0);
+  // v1.168.0: the staged arrival runs 6.2s, so at t=6s the roll is live but the hand is not
+  // dealt yet — the 7s lease and a dealt hand no longer overlap. The premise the lease must
+  // beat is "the follow-cam has a node it wants", which is true from startRoll's camFocus on;
+  // the dealt hand is asserted below, after the lease lapses, where it can be true.
+  expect(
+    await page.evaluate(() => { const a: any = (window as any).__neural; return !!a.camFocus && a.currentPos != null; }),
+    "premise: the roll is live, so the follow-cam has a node it wants",
+  ).toBe(true);
   expect(
     s.litOnScreen,
     `${s.lit - s.litOnScreen} of ${s.lit} shared nodes are OFF a ${s.W}x${s.H} screen ${s.t}s ` +
@@ -242,6 +249,7 @@ test("the class a link lit is STILL ON SCREEN seconds after arrival, with the ro
   const before = s.cam;
   await j.advance(9000);
   const after = await screen(page);
+  expect(after.hand, "…and by now the hand IS dealt — the roll the lease was holding off is real").toBeGreaterThan(0);
   expect(
     after.currentOnScreen,
     `once the lease lapses the roll owns the camera again — current node ` +

--- a/e2e/journeys/share-mobile.spec.ts
+++ b/e2e/journeys/share-mobile.spec.ts
@@ -293,8 +293,9 @@ test("the sentence explaining the arrival waits until there is a settled screen 
       `opacity ${atZero.opacity}, t=${atZero.t}s)`,
   ).toBe(true);
 
-  // …and it arrives on the first landing: intro over, hand dealt, graph settled.
-  await j.advance(6000);
+  // …and it arrives on the first landing: intro over, the staged arrival (6.2s, v1.168.0)
+  // played out, hand dealt, graph settled.
+  await j.advance(10200);
   // the toast fades in over `transition:opacity .45s` — CSS transitions run on the REAL clock,
   // and pumped sim time passes none of it, so read the computed opacity after a real beat
   await page.waitForTimeout(600);

--- a/e2e/journeys/url-arrival.spec.ts
+++ b/e2e/journeys/url-arrival.spec.ts
@@ -163,7 +163,7 @@ test("pressing play is what starts the roll, and only then does it reach history
 test("the front door is untouched — / still deals its own first impression", async ({ page }) => {
   const j = journey(page)
   await j.boot("/")
-  await j.advance(6000)
+  await j.advance(10200) // intro 3.2s + the staged arrival 6.2s (v1.168.0) + the deal
   const a = await arrival(page)
   expect(a.seeded, "no node was named, so nothing was seeded").toBe(false)
   expect(a.paused, "and the roll is running, as it always has been").toBe(false)
@@ -255,30 +255,46 @@ test("the camera frames the space the card WILL occupy, not the gap while it reb
  * aim drift **13.06 world units → 0.28**. The camera now makes ONE approach to a target that was
  * right from the first frame, instead of chasing one that moves under it.
  */
-test("@curated the opening flight has a fixed aim, not one that drifts as the card mounts", async ({
+test("@curated the opening flight is piecewise-fixed: one wide aim, one landing aim, no drift in either", async ({
   page,
 }) => {
   const j = journey(page)
   await j.boot("/")
   await j.advance(3300) // the intro hands the camera over at 3.2s
 
-  const aims: number[] = []
-  for (let i = 0; i < 14; i++) {
-    await j.advance(400)
-    const cy = await page.evaluate(() =>
-      (window as any).__neural.camTarget ? (window as any).__neural.camTarget.cy : null,
-    )
-    if (cy != null) aims.push(cy)
+  // v1.168.0 CHANGED THE CLAIM, NOT THE BUG THIS SPEC PINS. The staged arrival aims WIDE for
+  // its first beat (NG_ARRIVE_KICKER = 2.0s) and then re-aims ONCE at the landing framing — a
+  // designed retarget at a designed moment. What must still never happen is the original
+  // defect: the aim moving UNDER the flight because the card mounted or the band's cold prior
+  // gave way. So each phase is sampled separately and pinned to zero drift, and phase B's
+  // window deliberately spans enterLand (~9.4s) and the card's mount — the exact event whose
+  // aim-shift this spec exists to forbid.
+  const sample = async (n: number) => {
+    const out: number[] = []
+    for (let i = 0; i < n; i++) {
+      await j.advance(400)
+      const cy = await page.evaluate(() =>
+        (window as any).__neural.camTarget ? (window as any).__neural.camTarget.cy : null,
+      )
+      if (cy != null) out.push(cy)
+    }
+    return out
   }
-  expect(aims.length, "the flight was sampled").toBeGreaterThan(10)
+  const wide = await sample(4) // 3.3s → 4.9s: the kicker beat, camera on the whole graph
+  const gcy = await page.evaluate(() => (window as any).__neural.gcy)
+  expect(wide.length, "the wide beat was sampled").toBeGreaterThan(2)
+  for (const cy of wide)
+    expect(Math.abs(cy - gcy), "beat 1 aims at the graph's own centre, every sample").toBeLessThan(3)
 
-  // THE CLAIM: the aim is settled from the first sample. Not "the camera is instantly there" —
-  // it still flies, and should — but it flies to ONE place.
+  await j.advance(700) // cross the beat boundary at 5.2s
+  const aims = await sample(14) // 5.6s → 11.2s: the approach, the landing AND the card's mount
+  expect(aims.length, "the flight was sampled").toBeGreaterThan(10)
   const drift = Math.max(...aims) - Math.min(...aims)
   expect(
     drift,
-    `the opening aim does not move under the flight (drift ${drift.toFixed(2)} world units across ${aims.length} samples)`,
+    `the landing aim does not move under the flight — card mount included (drift ${drift.toFixed(2)} world units across ${aims.length} samples)`,
   ).toBeLessThan(3)
+  await j.advance(1500) // let the tween settle before measuring where it landed
 
   // ...AND IT LANDS IN THE BAND, not at the screen's middle. Measured against the card that by now
   // exists, which is the surface the band is carved out of.

--- a/neural/src/app.src.jsx
+++ b/neural/src/app.src.jsx
@@ -141,6 +141,23 @@ class Component extends DCLogic {
   // (v1.114.0: it no longer decides whether the state is NAMED — the label beside the node is
   // the one naming design at every zoom. See THE ARRIVAL IS THE EVENT, below.)
   ROLL_ZOOM = 0.085;
+  // ── THE STAGED ARRIVAL (v1.168.0, owner) ──────────────────────────────────────────────────
+  // The restart used to print kicker+name+role+opponent ALL AT ONCE for 1.3s while the canvas
+  // label named the same state beside the orb — the position and the role each printed twice,
+  // at the same moment. It is now a sequence with a hand-off: the kicker rides alone while the
+  // camera breathes OUT to the whole graph, then the state names itself (name + role — the
+  // opponent is gone from this line: `_ladder.rank` never touched the AI, see ladderState) as
+  // the camera flies to the landing framing, then the centre block cross-fades INTO the canvas
+  // label, which is at full strength exactly when the flight settles. Total 6.2s, owner-tuned
+  // on the "Between Rolls" motion prototype (2.0 / 2.4 / 1.8). The verdict holds in endRound
+  // grew round(x1.5) in the same ruling, with a "New roll in 3s…" countdown on their tail.
+  NG_ARRIVE_KICKER = 2.0;   // "Restarting the roll", alone, camera wide
+  NG_ARRIVE_NAME = 2.4;     // the state fades in; the flight to the landing framing begins
+  NG_ARRIVE_HANDOFF = 1.8;  // centre block out, canvas label in — a cross-fade, not a cut
+  /** Every arrival stamp dies here — the complete lifter set is this call (§6.5): the normal
+   *  path (enterLand), and both user takeovers (rollFromPosition, stageRollAt). `_arriveWide`
+   *  also carries its own deadline in updateCamera, so a missed lifter costs 2s, not forever. */
+  _endArrival() { this._arriveWide = false; this._arriveGlideUntil = null; this._arriveLabelT = null; }
   /** The resting light on the state you are STANDING IN — present always, hugging the orb.
    *  Not the retired halo: a third of its alpha and a quarter of its reach. See v1.114.1. */
   REST_GLOW = 0.42;
@@ -10747,12 +10764,36 @@ class Component extends DCLogic {
   showCenter(kicker, text, sub, tone, small) {
     const col = this.toneColor(tone);
     const k = this.evcKickerRef.current, t = this.evcTextRef.current, s = this.evcSubRef.current, box = this.evCenterRef.current;
+    // EVERY WRITE RELEASES THE ARRIVAL'S STYLING (§6.5 — the stamp rule). `_centerReveal` fades
+    // the text/sub in with inline opacity, and `_centerHandoff` stretches the box's fade to the
+    // hand-off length; if a verdict or capstone writes next while either is mid-flight, it must
+    // get the stock instant text and .55s box fade back, not the arrival's leftovers.
+    if (box) box.style.transitionDuration = "";
+    for (const el of [t, s]) if (el) { el.style.transition = ""; el.style.opacity = ""; }
     if (k) { k.textContent = kicker; k.style.color = col; }
     if (t) { t.textContent = text; t.style.color = tone === "good" ? "#cfe6ff" : tone === "bad" ? "#ffd6d6" : "#eef1f6"; t.style.fontSize = small ? "clamp(26px,3.2vw,38px)" : "clamp(40px,6vw,68px)"; }
     if (s) s.textContent = sub || "";
     if (box) box.style.opacity = "1";
   }
   hideCenter() { const box = this.evCenterRef.current; if (box) box.style.opacity = "0"; }
+  /** Beat 2 of the staged arrival: the name and the role fade into the already-showing centre
+   *  block. Inline opacity + transition, both reset by the next showCenter (see above). */
+  _centerReveal(text, sub) {
+    for (const [el, val] of [[this.evcTextRef.current, text], [this.evcSubRef.current, sub]]) {
+      if (!el) continue;
+      el.textContent = val;
+      el.style.transition = "opacity .6s ease";
+      el.style.opacity = "0";
+      requestAnimationFrame(() => requestAnimationFrame(() => { el.style.opacity = "1"; }));
+    }
+  }
+  /** Beat 3: the centre block fades out over the whole hand-off while the canvas label ramps in
+   *  (draw() reads `_arriveLabelT`) — the state is never named twice at full strength. */
+  _centerHandoff() {
+    const box = this.evCenterRef.current; if (!box) return;
+    box.style.transitionDuration = this.NG_ARRIVE_HANDOFF + "s";
+    box.style.opacity = "0";
+  }
 
   /**
    * `nodeIdx` (v1.106.5) names the node the round ENDED on — the submission you finished with, or
@@ -10808,18 +10849,27 @@ class Component extends DCLogic {
     if (this.adv) this.adv.shown = false;
     this.pulse = null; this.optionIdxs = [];
     const map = {
-      win: { k: "Submission", big: "You finished it", tone: "good", hold: 4.4 },
-      lose: { k: "Tapped out", big: "You got caught", tone: "bad", hold: 3.8 },
-      reset: { k: "Scramble", big: "Roll reset", tone: "muted", hold: 2.8 },
+      // round(hold x 1.5), owner (v1.168.0): "it's too fast in between game end and new roll".
+      // The dead time is also LABELLED now — the announcer counts the last three seconds down,
+      // so the wait reads as a timer, not a hang. Was 4.4 / 3.8 / 2.8.
+      win: { k: "Submission", big: "You finished it", tone: "good", hold: 6.6 },
+      lose: { k: "Tapped out", big: "You got caught", tone: "bad", hold: 5.7 },
+      reset: { k: "Scramble", big: "Roll reset", tone: "muted", hold: 4.2 },
     };
     const m = map[kind] || map.reset;
     if (this.evRef.current) this.evRef.current.style.opacity = "0";
     this.showCenter(m.k, m.big, name || "", m.tone);
     this.endCenter = { x: this.nodes[this.currentPos].x, y: this.nodes[this.currentPos].y };
     this.endZoom = true;
+    // "New roll in 3s… 2s… 1s…" rides the verdict's tail. Plain setEvent on purpose: the
+    // announcer is ONE slot and any later writer wins (§6.5) — a capstone banner or a share
+    // arrival simply overwrites a tick, and the next tick concedes the same way.
+    for (const sLeft of [3, 2, 1]) {
+      this.after(m.hold - sLeft, () => this.setEvent("Restarting", "New roll in " + sLeft + "s\u2026", "muted"));
+    }
     this.after(m.hold, () => {
       this.hideCenter();
-      this.after(0.55, () => { this.endZoom = false; this.startRoll(); });
+      this.after(0.8, () => { this.endZoom = false; this.startRoll(); }); // was 0.55; same x1.5 ruling
     });
   }
 
@@ -12898,6 +12948,10 @@ class Component extends DCLogic {
       return false;   // the board keeps the roll it has; a URL arrival never reaches here (NONE
                       // above) and every other caller is acting on an already-live board.
     }
+    // A user takeover mid-arrival ends the staged arrival — wide camera, glide and label ramp
+    // all yield. AFTER the ruleset guard on purpose: a REFUSED seat keeps the roll the board
+    // has, and if that roll is mid-arrival its choreography must keep playing undisturbed.
+    this._endArrival();
     // start a NEW roll seeded at a chosen position; the current roll is archived into Previous rolls
     // A NEW ROLL ENDS THE FILM, FIRST (v1.106.5) — before `clearTimers()` takes its step timer and
     // before this function writes the camera. `setPaused` also stops a replay, but it is called at
@@ -13575,15 +13629,36 @@ class Component extends DCLogic {
     this._prefetchLandDeck(this.currentPos); // the intro is the deck's runway (v1.106.6)
     const lad = this.ladderState();
     this.fx("stakes", { rank: lad.rank, opponent: lad.opponent });
-    // A weak-spots opening names the CRACK it is about — the technique or the position — instead
-    // of the generic restart kicker; the rest of the toast is unchanged.
-    this.showCenter(this._startSpot ? "Your weak spot: " + this._startSpot.split("|")[0] : "Restarting the roll", this.posFamily(this.nodes[this.currentPos].t), this.roleLabel() + " \u00b7 vs " + lad.opponent, "muted", true);
+    // THE STAGED ARRIVAL (v1.168.0) — see the NG_ARRIVE_* block for the design. Three beats:
+    //   1. the kicker ALONE, camera wide ("the whole graph breathes out");
+    //   2. the state fades in — name + role, no opponent (the belt label never touched the AI);
+    //   3. the centre hands off to the canvas label as the flight settles.
+    // The announcer's countdown ends the moment this begins.
+    this._rollsBegun = (this._rollsBegun || 0) + 1;
+    if (this.evRef.current) this.evRef.current.style.opacity = "0";
+    // A weak-spots opening names the CRACK it is about (v1.166.0) — that kicker survives the
+    // staged cut and rides beat 1 alone. Otherwise the session's FIRST roll is not a restart —
+    // "Restarting" on a first visit was the owner's original complaint, and no earlier roll
+    // exists for the word to be true of.
+    this.showCenter(
+      this._startSpot ? "Your weak spot: " + this._startSpot.split("|")[0]
+        : this._rollsBegun > 1 ? "Restarting the roll" : "Starting the roll",
+      "", "", "muted", true);
     this.focusIdx = this.currentPos; this.pulse = null;
     this.camFocus = this.pairMid(this.nodes[this.currentPos]);
     this.prevPosVal = this.myVal(this.nodes[this.currentPos]);
     this._played = false;
+    this._arriveWide = true;   // camera beat 1 — updateCamera also holds this to a hard deadline
+    this._arriveWideUntil = this.now + this.NG_ARRIVE_KICKER + 0.5;
+    this._arriveGlideUntil = this.now + this.NG_ARRIVE_KICKER + this.NG_ARRIVE_NAME + this.NG_ARRIVE_HANDOFF;
+    this._arriveLabelT = this.now + this.NG_ARRIVE_KICKER + this.NG_ARRIVE_NAME; // hand-off start
     this.flare(this.currentPos);
-    this.after(1.3, () => this.enterLand(true));
+    this.after(this.NG_ARRIVE_KICKER, () => {
+      this._arriveWide = false;   // beat 2: the follow-cam flies to the landing framing
+      this._centerReveal(this.posFamily(this.nodes[this.currentPos].t), this.roleLabel());
+    });
+    this.after(this.NG_ARRIVE_KICKER + this.NG_ARRIVE_NAME, () => this._centerHandoff());
+    this.after(this.NG_ARRIVE_KICKER + this.NG_ARRIVE_NAME + this.NG_ARRIVE_HANDOFF, () => this.enterLand(true));
   }
 
   startLandRipple(centerIdx, neighborIdxs) {
@@ -13618,7 +13693,8 @@ class Component extends DCLogic {
     this.focusIdx = this._stagedTech ? this._stagedTech.idx : this.currentPos; this.pulse = null;
     this._settleT = this.now;
     this.activeMove = null;
-    this.hideCenter(); // clear the "Restarting the roll" center toast as play begins
+    this.hideCenter(); // clear the arrival's center toast as play begins
+    this._endArrival(); // the normal lifter: the flight is over, the label is at full strength
     // THE LANDING IS the arrival, so it carries the arrival bloom (v1.114.0). This re-flare fires
     // AFTER updateTravel's, on the same node — without the amplitude here it would immediately
     // demote the destination's bloom back to a pass-through's and restart its decay, i.e. the
@@ -14781,6 +14857,11 @@ class Component extends DCLogic {
       tgt = null;
     } else if (this.endZoom) {
       tgt = { cx: this.endCenter.x, cy: this.endCenter.y, vw: this.graphW * 1.55 };
+    } else if (this._arriveWide && this.now < (this._arriveWideUntil || 0)) {
+      // ARRIVAL BEAT 1 (v1.168.0): the whole graph, the intro's own parting framing. The
+      // deadline is the flag's own lease (§6.5) — every lifter lives in _endArrival(), and a
+      // missed one costs half a second past the beat, never a stuck-wide camera.
+      tgt = { cx: this.gcx, cy: this.gcy, vw: this.graphW * 1.0 };
     } else {
       const mode = this.cfg().cameraMode;
       if (mode === "Overview") {
@@ -14814,8 +14895,14 @@ class Component extends DCLogic {
     // viewport shrinks quicker than the target centers and mid-flight shows empty space instead of
     // the glowing node you're flying toward.
     const flight = this._dossierIdx != null;
-    const tauP = !this.introDone ? 0.8 : flight ? 0.28 : 0.5;
-    const tauV = !this.introDone ? 0.9 : flight ? 0.7 : 0.55;
+    // ARRIVAL GLIDE (v1.168.0, owner: "the zoom in needs to be slower"): the staged arrival's
+    // out-and-in is one long breath, tau ~1s, timed so the flight settles as the hand-off ends.
+    // A user's own camera (a lease, or live input) gets the stock pace back immediately —
+    // their flight must never inherit the arrival's slowness.
+    const arriveGlide = this._arriveGlideUntil != null && this.now < this._arriveGlideUntil
+      && !this.camHeld() && !this.userActiveNow();
+    const tauP = !this.introDone ? 0.8 : arriveGlide ? 1.0 : flight ? 0.28 : 0.5;
+    const tauV = !this.introDone ? 0.9 : arriveGlide ? 1.05 : flight ? 0.7 : 0.55;
     const aP = 1 - Math.exp(-dt / tauP), aV = 1 - Math.exp(-dt / tauV);
     this.cam.cx += (this.camTarget.cx - this.cam.cx) * aP;
     this.cam.cy += (this.camTarget.cy - this.cam.cy) * aP;
@@ -15164,6 +15251,13 @@ class Component extends DCLogic {
     const rsOk = this._rulesetMask();
     const cfg = this.cfg();
     const A = this.alpha;
+    // ARRIVAL HAND-OFF RAMP (v1.168.0): 0 while the centre block is the only thing naming the
+    // state, easing to 1 across the hand-off so the canvas label is at full strength exactly
+    // when the flight settles. `_arriveLabelT` is a stamp on the game clock; null (or any past
+    // arrival) reads as 1, so every non-arrival frame draws exactly what it always drew — and a
+    // takeover clears the stamp in _endArrival(), so a NEW focus is never born half-invisible.
+    const arriveA = this._arriveLabelT == null ? 1
+      : Math.max(0, Math.min(1, (this.now - this._arriveLabelT) / this.NG_ARRIVE_HANDOFF));
     // slow-mo finish: dim the map for a beat while the finishing flare burns, then recover
     let dim = 1;
     if (this._slowmo) {
@@ -15648,6 +15742,7 @@ class Component extends DCLogic {
       // rich label = role + name, anchored beside a node
       const richLabel = (idx, role, roleCol, name, big) => {
         const n = this.nodes[idx]; if (!n) return;
+        const lA = big ? A * arriveA : A; // big = the focused state's label — it rides the arrival ramp
         const sx = (n.x - this.cam.cx) * scale + W / 2, sy = (LY(n) - this.cam.cy) * scale + H / 2;
         if (sx < -120 || sx > W + 260 || sy < -30 || sy > H + 50) return;
         const ox = sx + halfW(n) + 11;
@@ -15655,11 +15750,11 @@ class Component extends DCLogic {
         ctx.textBaseline = "alphabetic";
         const dfam = this._displayFam || "'Space Grotesk'";
         ctx.font = "700 " + (big ? 11 : 10) + "px " + dfam + ", sans-serif";
-        ctx.fillStyle = this.rgba(roleCol, A);
+        ctx.fillStyle = this.rgba(roleCol, lA);
         ctx.fillText(role.toUpperCase(), ox, sy - (big ? 7 : 5));
         const rNamePx = big ? this.nameFontPx() : 13;
         ctx.font = (big ? "700 " : "600 ") + rNamePx + "px " + dfam + ", sans-serif";
-        ctx.fillStyle = this.rgba({ r: 240, g: 243, b: 248 }, A);
+        ctx.fillStyle = this.rgba({ r: 240, g: 243, b: 248 }, lA);
         ctx.fillText(name, ox, sy + (big ? 11 : 9));
         ctx.shadowBlur = 0;
         // published for the same reason `_lastPairLabel` is: this is canvas text with no DOM to
@@ -15762,7 +15857,7 @@ class Component extends DCLogic {
         ctx.textBaseline = "alphabetic";
         // a pair you are merely POINTING AT is not the state you are in — it reads one step back
         // so the focus keeps its rank on a graph where every position is now a pair (v1.125.0).
-        const aF = focused ? A : A * 0.86;
+        const aF = focused ? A * arriveA : A * 0.86; // the focused label rides the arrival ramp
         // ── THE BLOCK STRADDLES THE MIDLINE, NOT THE NAME (v1.129.4) ────────────────────────
         // Owner: "those from wtv position look poorly aligned. rule is when those extra subtitles
         // show, the label shouldnt be aligned at the center, but rather the label and the 'from

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bjjgraph",
-  "version": "1.167.1",
+  "version": "1.168.0",
   "description": "BJJ knowledge graph and state machine",
   "scripts": {
     "postinstall": "cd source && npm install",


### PR DESCRIPTION
Owner-directed, tuned live on the "Between Rolls" motion prototype over two rounds. The restart used to print kicker + name + role + opponent **all at once** for 1.3s while the canvas label named the same state beside the orb — the position and the role each printed twice, at the same moment — and the gap between a finish and the next roll was too short to read any of it.

## The new cut (2.0 / 2.4 / 1.8 = 6.2s arrival)

- **endRound**: verdict holds grew `round(×1.5)` — 4.4/3.8/2.8 → **6.6/5.7/4.2**, gap 0.55 → 0.8, and the announcer counts the last three seconds down (`Restarting · New roll in 3s…`). The dead time is labelled, so it reads as a timer, not a hang.
- **Beat 1 (2.0s)**: the kicker **alone** — *Starting the roll* on the session's first roll, *Restarting the roll* after — while the camera breathes out to the whole graph.
- **Beat 2 (2.4s)**: the state fades in — name + role only. The opponent is **gone** from this line: `_ladder.rank` never reached the outcome math (`aiSkill = difficulty + rng("ai-skill")`), so "vs Fresh White Belt" was decoration.
- **Beat 3 (1.8s)**: a true cross-fade — the centre block fades over the whole hand-off while the canvas label ramps in, at full strength exactly when the flight settles. The state is never named twice at full strength.

## Named open decision, not a side effect

The ladder machinery is untouched and now renders **nowhere** — rank persists, `ladder_up`/`ladder_down` still sound. Surface it, wire it into `aiSkill`, or retire it: owner's call, separately.

## Camera

New `_arriveWide` branch aims at the graph's own centre for beat 1, carrying its **own deadline** so a missed lifter costs half a second, never a stuck-wide camera; every lifter lives in `_endArrival()` (enterLand, rollFromPosition). The arrival glides at tau ~1.0s, settling as the hand-off ends; a user's own lease or live input gets the stock pace back instantly. `showCenter` resets every style the staged writers touch, so an interrupting verdict can never inherit a 1.8s fade or invisible text.

## Specs — four timing premises, one changed claim

- Fixed advances expecting the first hand at ≤6s moved to 10.2s (intro 3.2 + arrival 6.2 + deal): `announcer-coherence`, `share-mobile`, `url-arrival` front-door.
- `share-camera`: the 7s share lease and a dealt hand no longer overlap in time — the premise becomes "the roll is live and the follow-cam has a want", and the dealt hand is asserted after the lease lapses, where it can be true.
- `url-arrival` "fixed aim" → **"piecewise-fixed"**: beat 1 pins every sample to the graph centre; phase B pins zero drift across a window that deliberately spans enterLand *and* the card's mount — the exact event whose aim-shift the spec exists to forbid. The claim changed with the design; the bug it pins did not.
- `dsl.land()` pumps to 16s (was 12).

## Verification

Live-verified in a real browser (beat states, countdown ticks, fade durations, stamp cleanup); the four repaired specs green individually; previous curated run was 209/213 with exactly these four. The local full-suite run was killed by machine contention with a concurrent worktree's suite — CI's four shards are the authoritative full run for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQzUuzmtheLRKzGHG1wmKQ