### PR TITLE
v1.173.2 - Fix qualified node labels

### DIFF
--- a/docs/Changelog-Archive.md
+++ b/docs/Changelog-Archive.md
@@ -6629,3 +6629,27 @@ own note, and flagged as the owner's call: the ceilings are targets from Observa
 and this is 0.36% of the first-hand payload. The two refactors are deliberately NOT in that
 commit — the box's root disk was 100% full and could not run Playwright, so the shipped tree is
 byte-for-byte the one CI validated and only the number moved.
+
+## v1.173.2 — THE QUALIFIER STAYS A SUBTITLE AT EVERY ZOOM
+
+**Owner:** on `Trap and Roll from Mount / DEFENDING` — the gap between `from Mount` and
+`DEFENDING` became conspicuously large, and zooming out moved `from Mount` back into the title.
+
+**What was true.** The split-pair path already rendered `Trap and Roll` and `from Mount` on
+separate rows, but its lower role used the 24px headline's clearance and then followed the lower
+orb even farther away. The minimum qualifier-to-role baseline gap was therefore 23px against the
+15px rhythm of the two name rows. Below the pair merge threshold, a different renderer took over:
+the focus fallback passed `displayName(n)` into `richLabel`. Because `Trap and Roll` is ambiguous
+across origins, `displayName` correctly returned the full authored name — but `richLabel` had only
+one name row, so it recomposed the qualifier into the headline.
+
+**What is true now.** `richLabel` owns the graph naming structure and accepts no caller-composed
+name: it always draws `graphName(n)` as the headline and `splitName(n.t).from` as the optional
+qualifier. `_labelWidthPx` measures the widest of those actual rows rather than the retired inline
+string. In a qualified lower pair, the role sits one `NG_LABEL_LEAD` below the qualifier; upper
+roles and unqualified lower roles keep their orb-following behavior.
+
+**Pinned by:** `tests/neural_type_scale.test.mjs` runs the real wire through the real `ingest()` and
+`draw()` paths with the reported defender node, records the actual `fillText` calls, and checks
+both LODs. `e2e/journeys/graph-naming.spec.ts` renders the real canvas at split and merge scales,
+asserts the published geometry, and reads back positive pixels from every affected row.

--- a/docs/Neural.md
+++ b/docs/Neural.md
@@ -234,14 +234,16 @@ survives only as the cold-pool fallback, with ONE warm-upgrade attempt per deck 
 cannot build MC must not loop). The bottom-left legend lost the "+7 Tilt toward winning" row
 (owner: "the bar already shows that nicely") and the Win–Lose bar dropped to 165×7px.
 
-### The pair label (v1.135.0)
+### The pair label (v1.135.0; compact qualified stack v1.173.2)
 
-The pair label group anchors at the pair MIDLINE — "the name never moves" — but **the role word
-rides its orb**: `subY = min(nameY − 18, orbY + 4)` above (mirrored below), clamped to the
-block's clearances, so an ordinary ~35px pair keeps the old offsets (±1px) and a wide roll-zoom
-split puts TOP beside the blue orb it names instead of floating equidistant from both members
-(the owner's "why does top mount look red" — the eye bound the midline label to the red bottom
-orb). Published as `_lastPairLabel.subY`; pinned by `dual-pair.spec.ts`.
+The pair label group anchors at the pair MIDLINE — "the name never moves". A role word adjacent to
+the headline **rides its orb**: `subY = min(nameY − clearance, orbY + 4)` above (mirrored below), so
+a wide split binds TOP to the blue orb it names instead of the red bottom orb. One exception keeps
+a qualified lower label legible: `from …` and DEFENDING/ESCAPING are adjacent subtitle rows, one
+`NG_LABEL_LEAD` apart, rather than letting the lower role chase its orb and open a large hole in the
+stack. At merge scale `richLabel` preserves the same short headline plus qualifier row; zoom never
+recomposes `from …` into the title. Geometry is published through `_lastPairLabel` and
+`_lastRichLabel`; the pair behavior is pinned by `dual-pair.spec.ts` and `graph-naming.spec.ts`.
 
 ### The turn-based shell (v1.134.0)
 
@@ -494,11 +496,12 @@ purpose, because they are asking about the exchange, not about your hand.
 `deg` is geometry and stays split; `siteDeg` is the state and is the hub's. `cal.ev` goes on
 **both** halves whole, because the side you are playing can differ from the half you stand on.
 
-**Labels.** `pairGroup` renders one label group for the pair: the name pinned to the midline, the
-qualifier beneath it, and the role subtitle on the outside of whichever half you point at. When a
-qualifier renders, the two-row block straddles the midline. Role words are per category — positions
-**TOP/BOTTOM**, submissions **FINISHING/ESCAPING**, transitions **ATTEMPTING/DEFENDING**. The graph
-never bakes a role into a name (`graphName`).
+**Labels.** `pairGroup` renders one label group for the pair: the name block pinned to the midline,
+the qualifier beneath the headline, and the role on the side of whichever half you point at. A
+qualified lower role joins that subtitle stack at the same row lead; all other split roles ride
+their orb. `richLabel` keeps the headline and qualifier separate after the pair merges. Role words
+are per category — positions **TOP/BOTTOM**, submissions **FINISHING/ESCAPING**, transitions
+**ATTEMPTING/DEFENDING**. The graph never bakes a role into a name (`graphName`).
 
 ---
 

--- a/e2e/journeys/dual-pair.spec.ts
+++ b/e2e/journeys/dual-pair.spec.ts
@@ -679,7 +679,7 @@ test("@curated the phone frames the orb AND its name, centred together", async (
       const sx = (mid.x - a.cam.cx) * scale + a.W / 2
       // the focus mark is 1.28x the orb (v1.114.0), which is the silhouette the label clears
       const r = Math.max(f.r * K * scale, partner ? partner.r * K * scale : 0) * 1.28
-      const w = a._labelWidthPx(f, f.pi >= 0)
+      const w = a._labelWidthPx(f)
       return { W: a.W, orbSx: sx, left: sx - r, right: sx + r + 11 + w, labelW: w }
     })
 
@@ -740,7 +740,7 @@ test("@curated on a narrow phone the clamp holds the orb off the edge, and the n
       const p = f.pi >= 0 ? a.nodes[f.pi] : null
       const sx = (a.pairMid(f).x - a.cam.cx) * scale + a.W / 2
       const r = Math.max(f.r * K * scale, p ? p.r * K * scale : 0) * 1.28
-      const lw = a._labelWidthPx(f, f.pi >= 0)
+      const lw = a._labelWidthPx(f)
       return {
         W: a.W,
         min: a.NG_LABEL_LEFT_MIN,

--- a/e2e/journeys/graph-naming.spec.ts
+++ b/e2e/journeys/graph-naming.spec.ts
@@ -874,3 +874,125 @@ test("@curated zoomed out, the focus label says the side and not the category", 
       `and never names the category — the shape already does (drew "${m.rich.kicker}")`,
     ).not.toContain(w)
 })
+
+/**
+ * A QUALIFIER STAYS A SUBTITLE AT EVERY LOD (v1.173.2). @curated
+ *
+ * Owner, on `Trap and Roll from Mount / DEFENDING`: the lower role could follow its orb far enough
+ * away that the two subtitle rows stopped reading as one group. At merge scale `pairGroup` stands
+ * down and `richLabel` used `displayName`, which put `from Mount` back into the headline entirely.
+ *
+ * The exact reported node is the control. While split, the lower role follows the same baseline
+ * rhythm as the qualifier instead of opening an orb-sized hole. Once merged, the renderer still
+ * publishes and draws the short headline plus its separate qualifier; zoom changes geometry, not
+ * naming structure.
+ */
+test("@curated a qualified focus keeps a compact subtitle stack when zooming out", async ({
+  page,
+}) => {
+  const j = journey(page)
+  await j.boot("/Transitions/Trap-and-Roll-from-Mount/Defender")
+
+  // One real canvas frame at each LOD is the subject. Base links do not participate in labels;
+  // suppressing that pass keeps this focused render deterministic on software-rasterized runners
+  // while the positive count proves the full shipped graph was ingested before isolation.
+  const { edgeCount, focus, role, split, merged } = await page.evaluate(() => {
+    const a = (window as Any).__neural
+    const idx = a._urlSeedIdx
+    const n = a.nodes[idx]
+    if (!n || n.t !== "Trap and Roll from Mount" || n.role !== "defender")
+      throw new Error(`reported URL resolved to ${n ? `${n.t}/${n.role}` : "nothing"}`)
+    const partner = a.nodes[n.pi]
+    if (!partner) throw new Error("reported node has no pair")
+    const edgeCount = a.links.length
+    a.links = []
+    a.ripples = []
+    a.trail = []
+    a.optionIdxs = []
+    a._focusIdxSet = null
+    a._sessionNodes = []
+    a._dangerSet = null
+    a._pathDim = false
+    a.introDone = true
+    a.focusIdx = idx
+    a.currentPos = idx
+    a.playerRole = a._urlSeedRole || "top"
+    a.paused = true
+    a.pulse = null
+    a.activeMove = null
+    a._hover = null
+    a._arriveLabelT = null
+    a.alpha = 1
+    a.now = 10
+    a.startTime = 0
+    a.cam.cx = n.x
+    a.cam.cy = (n.y + partner.y) / 2
+    const drawAt = (scale: number) => {
+      a.cam.vw = a.W / scale
+      a.cam.lvw = Math.log(a.cam.vw)
+      a.draw()
+      const label = a._lastPairLabel || a._lastRichLabel
+      const inkAt = (y: number, above: number, below: number) => {
+        if (!label || y == null) return 0
+        const canvas: HTMLCanvasElement = a.canvas
+        const ctx = canvas.getContext("2d")!
+        const dpr = canvas.width / canvas.clientWidth
+        const x = Math.max(0, Math.floor((label.ox - 2) * dpr))
+        const top = Math.max(0, Math.floor((y - above) * dpr))
+        const width = Math.max(1, Math.min(canvas.width - x, Math.ceil(260 * dpr)))
+        const height = Math.max(1, Math.min(canvas.height - top, Math.ceil((above + below) * dpr)))
+        const data = ctx.getImageData(x, top, width, height).data
+        let ink = 0
+        for (let i = 0; i < data.length; i += 4)
+          if (0.2126 * data[i] + 0.7152 * data[i + 1] + 0.0722 * data[i + 2] > 70) ink++
+        return ink
+      }
+      return {
+        lodK: a._lodK,
+        pair: a._lastPairLabel,
+        rich: a._lastRichLabel,
+        ink: label && {
+          name: inkAt(label.nameY, label.namePx, 3),
+          qual: inkAt(label.qualY, 12, 3),
+          role: inkAt(label.subY == null ? label.roleY : label.subY, 12, 3),
+        },
+      }
+    }
+    return {
+      edgeCount,
+      focus: n.t,
+      role: n.role,
+      split: drawAt(3),
+      merged: drawAt(1),
+    }
+  })
+
+  expect(edgeCount, "the isolated frame came from the full shipped graph").toBeGreaterThan(2000)
+  expect(focus).toBe("Trap and Roll from Mount")
+  expect(role).toBe("defender")
+  expect(split.lodK, "the reported label starts with its two role orbs split").toBeGreaterThan(0.5)
+  expect(split.pair, "the focused pair drew its label group").toBeTruthy()
+  expect(split.pair.main).toBe("Trap and Roll")
+  expect(split.pair.qual).toBe("from Mount")
+  expect(split.pair.sub).toBe("DEFENDING")
+  expect(split.pair.above, "DEFENDING is the lower role").toBe(false)
+  expect(
+    split.pair.subY - split.pair.qualY,
+    "the two subtitle rows keep the same baseline rhythm as the title and qualifier",
+  ).toBeCloseTo(split.pair.qualY - split.pair.nameY, 1)
+  expect(split.ink.name, "the title row is visible on the canvas").toBeGreaterThan(30)
+  expect(split.ink.qual, "the qualifier row is visible on the canvas").toBeGreaterThan(10)
+  expect(split.ink.role, "the role row is visible on the canvas").toBeGreaterThan(10)
+
+  expect(merged.lodK, "the same label reached merge scale").toBeLessThan(0.5)
+  expect(merged.pair, "the split-pair group stood down").toBeFalsy()
+  expect(merged.rich, "the merged focus drew its rich label").toBeTruthy()
+  expect(merged.rich.name, "the headline stays short").toBe("Trap and Roll")
+  expect(merged.rich.qual, "the origin remains its own subtitle").toBe("from Mount")
+  expect(
+    merged.rich.qualY,
+    "the qualifier has a rendered baseline below the headline",
+  ).toBeGreaterThan(merged.rich.nameY)
+  expect(merged.ink.name, "the merged title row is visible on the canvas").toBeGreaterThan(30)
+  expect(merged.ink.qual, "the merged qualifier row is visible on the canvas").toBeGreaterThan(10)
+})

--- a/neural/src/app.src.jsx
+++ b/neural/src/app.src.jsx
@@ -15245,7 +15245,7 @@ class Component extends DCLogic {
     // here has any reason to overturn.
     let cx = f.x + 0.06 * vw;
     if (this.isMobile() && n) {
-      const labelW = this._labelWidthPx(n, !!(n.pi >= 0));
+      const labelW = this._labelWidthPx(n);
       if (labelW > 0) {
         // centre the orb+label block…
         let px = W / 2 - (11 + labelW) / 2;
@@ -15261,17 +15261,15 @@ class Component extends DCLogic {
     }
     return { cx: cx, cy: cy, vw: vw };
   }
-  // THE WIDTH OF THE NAME THE GRAPH IS ABOUT TO DRAW, in px, measured with the font it draws it
-  // with. Cached per node + font size, because the follow-cam calls `rollCamTarget` every frame
-  // and `measureText` is not free. Measured on a SCRATCH context: `this.ctx` is mid-frame during
-  // a draw and its `font` is state, so borrowing it would be a heisenbug waiting to happen.
-  _labelWidthPx(n, paired) {
-    // ONE SOURCE WITH THE DRAW (v1.138.0). This was `paired ? 18 : 17`, a hand-copied mirror of the
-    // pair group's focused size and of richLabel's `big` — which had ALREADY drifted (richLabel
-    // draws `big` at the focus size, so 17 was simply wrong), and which nothing tied to the draw:
-    // `dual-pair.spec.ts` measures THIS, so a mismatch mis-frames the phone with every test green.
-    // `paired` no longer selects a size because both paths now draw the state's name at one rank;
-    // it is kept in the signature because the CACHE KEY and both call sites are written for it.
+  // THE WIDTH OF THE WIDEST ROW THE GRAPH IS ABOUT TO DRAW, in px, measured with that row's
+  // actual font. Cached per node + headline size, because the follow-cam calls `rollCamTarget`
+  // every frame and `measureText` is not free. Measured on a SCRATCH context: `this.ctx` is
+  // mid-frame state during a draw and its `font` is state, so borrowing it would be a heisenbug.
+  _labelWidthPx(n) {
+    // ONE SOURCE WITH THE DRAW (v1.138.0, two-row names v1.173.2). The pair group and the merged
+    // rich label now draw the same short headline plus optional qualifier. Measuring the old
+    // inline `displayName` after the draw stopped using it shifted qualified phone labels left by
+    // space the visible rows did not occupy.
     const px = this.nameFontPx();
     const key = n.idx + "|" + px;
     this._labelWCache = this._labelWCache || new Map();
@@ -15282,9 +15280,14 @@ class Component extends DCLogic {
       if (!this._measCtx) this._measCtx = document.createElement("canvas").getContext("2d");
       const c = this._measCtx;
       if (c) {
-        c.font = "700 " + px + "px " + (this._displayFam || "'Space Grotesk'") + ", sans-serif";
-        const nm = n.ty === "positions" ? this.posFamily(n.t) : this.displayName(n);
-        w = c.measureText(nm).width || 0;
+        const fam = this._displayFam || "'Space Grotesk'";
+        const sp = this.splitName(n.t);
+        c.font = "700 " + px + "px " + fam + ", sans-serif";
+        w = c.measureText(this.graphName(n)).width || 0;
+        if (n.ty !== "positions" && sp.from) {
+          c.font = "600 11.5px " + fam + ", sans-serif";
+          w = Math.max(w, c.measureText(sp.from).width || 0);
+        }
       }
     } catch (e) { w = 0; }   // no canvas: fall back to the orb-centred framing, never to a crash
     this._labelWCache.set(key, w);
@@ -16238,37 +16241,55 @@ class Component extends DCLogic {
         ctx.fillStyle = this.rgba({ r: 238, g: 241, b: 246 }, 0.8 * k * A);
         ctx.fillText(this.graphName(n), sx + halfW(n) + 9, sy - 7); ctx.shadowBlur = 0;
       }
-      // rich label = role + name, anchored beside a node
-      const richLabel = (idx, role, roleCol, name, big) => {
+      // Rich labels own the graph's naming structure: role + short headline + optional qualifier.
+      // Callers cannot pass a pre-composed name; that is how the merge-scale fallback used to put
+      // "from Mount" back into the headline while the split pair rendered it as a subtitle.
+      const richLabel = (idx, role, roleCol, big) => {
         const n = this.nodes[idx]; if (!n) return;
         const lA = big ? A * arriveA : A; // big = the focused state's label — it rides the arrival ramp
         const sx = (n.x - this.cam.cx) * scale + W / 2, sy = (LY(n) - this.cam.cy) * scale + H / 2;
         if (sx < -120 || sx > W + 260 || sy < -30 || sy > H + 50) return;
         const ox = sx + halfW(n) + 11;
+        const maxW = Math.max(60, W - ox - 12);
+        const sp = this.splitName(n.t);
+        const main = this.graphName(n);
+        const qual = n.ty === "positions" ? "" : sp.from || "";
+        // Shift the existing role/name pair together by half a row when a qualifier appears, so
+        // adding the third line does not move the visual centre of the whole merged label.
+        const lift = qual ? this.NG_LABEL_LEAD / 2 : 0;
+        const roleY = sy - (big ? 7 : 5) - lift;
+        const nameY = sy + (big ? 11 : 9) - lift;
+        const qualY = nameY + this.NG_LABEL_LEAD;
         ctx.shadowColor = "rgba(0,0,0,0.92)"; ctx.shadowBlur = 8;
         ctx.textBaseline = "alphabetic";
         const dfam = this._displayFam || "'Space Grotesk'";
         ctx.font = "700 " + (big ? 11 : 10) + "px " + dfam + ", sans-serif";
         ctx.fillStyle = this.rgba(roleCol, lA);
-        ctx.fillText(role.toUpperCase(), ox, sy - (big ? 7 : 5));
+        ctx.fillText(role.toUpperCase(), ox, roleY);
         const rNamePx = big ? this.nameFontPx() : 13;
         ctx.font = (big ? "700 " : "600 ") + rNamePx + "px " + dfam + ", sans-serif";
         ctx.fillStyle = this.rgba({ r: 240, g: 243, b: 248 }, lA);
-        ctx.fillText(name, ox, sy + (big ? 11 : 9));
+        const drawnMain = this._fitText(ctx, main, maxW);
+        ctx.fillText(drawnMain, ox, nameY);
+        let drawnQual = "";
+        if (qual) {
+          ctx.font = "600 " + (big ? "11.5px " : "10.5px ") + dfam + ", sans-serif";
+          drawnQual = this._fitText(ctx, qual, maxW);
+          ctx.fillStyle = this.rgba({ r: 240, g: 243, b: 248 }, lA * 0.62);
+          ctx.fillText(drawnQual, ox, qualY);
+        }
         ctx.shadowBlur = 0;
-        // published for the same reason `_lastPairLabel` is: this is canvas text with no DOM to
-        // query, and the anchor comes from `halfW`, a draw-local closure. Reading the strings the
-        // frame passed to `fillText` is the render's OUTPUT, not a re-derivation of its logic.
-        this._lastRichLabel = { idx: idx, kicker: role, name: name, big: !!big, namePx: rNamePx };
+        // Published draw output: canvas has no DOM, and `ox`/baselines are draw-local geometry.
+        this._lastRichLabel = { idx: idx, kicker: role, name: drawnMain, qual: drawnQual, big: !!big, ox: ox, roleY: roleY, nameY: nameY, qualY: qual ? qualY : null, namePx: rNamePx };
       };
       // active move during travel: "ATTACKING / Triangle Choke" etc.
       if (this.pulse && this.activeMove) {
         const am = this.activeMove;
         // a staged technique already wears the big pair label (name · qualifier · role) — the
-        // small unqualified travel label over it was the owner's "just 'armbar', tiny" report
+        // small travel label over it was the owner's "just 'armbar', tiny" report
         const fn = this.focusIdx >= 0 ? this.nodes[this.focusIdx] : null;
         const dup = fn && (am.idx === this.focusIdx || (fn.pairId && this.nodes[am.idx] && this.nodes[am.idx].pairId === fn.pairId));
-        if (!dup) richLabel(am.idx, am.verb, am.col, this.graphName(this.nodes[am.idx]), false);
+        if (!dup) richLabel(am.idx, am.verb, am.col, false);
       }
       // persistent labels on the outgoing option nodes while a decision is open
       this._lastOptLabels = null; // published like _lastPairLabel: "what did THIS frame draw"
@@ -16393,23 +16414,22 @@ class Component extends DCLogic {
         // the name's BODY instead of its tail and the mutant survived three different oracles.
         // Reading the strings the frame passed to `fillText` is not a re-implementation of the
         // render — it IS the render's output.
-        // THE ROLE WORD RIDES ITS ORB (v1.135.0 — owner: "why does top mount look red like i'm
-        // going to lose?"). The block anchors at the pair MIDLINE ("the name never moves"), which
-        // left TOP/BOTTOM floating equidistant from both orbs — measured 33px from each at roll
-        // zoom — so the eye could bind "TOP · Mount" to the red bottom orb underneath. The word
-        // now sits at its own member's drawn y whenever the split allows, clamped to the block's
-        // existing clearances so it can never land on the name or the qualifier; merged pairs
-        // (small gap) degenerate to the old offsets by construction.
+        // THE ROLE WORD RIDES ITS ORB (v1.135.0) unless that tears apart two adjacent subtitle
+        // rows (v1.173.2). Above roles still sit beside their upper member, and an unqualified
+        // lower role still follows its lower member. A qualified lower role instead sits exactly
+        // one shared row lead beneath `from …`: placement below the centred name block already
+        // identifies the lower half, while following a wide-split orb opened the reported void
+        // between "from Mount" and "DEFENDING".
         const syAct = (LY(act) - this.cam.cy) * scale + H / 2;
-        // THE CLEARANCE IS THE NAME'S, NOT A CONSTANT (v1.138.0). The literal 18 here was the
-        // ascender height of an 18px name plus ~5px of air; MEASURED on the shipped face, that
-        // name reaches 13px above its baseline, and a 24px one reaches 18px — so the old constant
-        // would have put TOP/BOTTOM exactly ON the name's ascenders at the new size. Derived, it
-        // reproduces 18 at both 15px and 18px (the floor holds the unfocused row where it was) and
-        // gives 23 at 24px, keeping the same 5px of air. Recompute the ascents with
-        // tests/artifacts/_label_size_probe.mjs.
-        const clr = Math.max(18, Math.round(namePx * 0.78 + 4));
-        const subY = above ? Math.min(nameY - clr, syAct + 4) : Math.max((qual ? qualY : nameY) + clr, syAct + 4);
+        // Where the role is adjacent to the headline, clearance scales with the headline's actual
+        // size: measured ascent plus 5px of air. The qualifier branch uses NG_LABEL_LEAD, whose
+        // measured small-text clearance is already shared by both canvas naming paths.
+        const nameClr = Math.max(18, Math.round(namePx * 0.78 + 4));
+        const subY = above
+          ? Math.min(nameY - nameClr, syAct + 4)
+          : qual
+            ? qualY + this.NG_LABEL_LEAD
+            : Math.max(nameY + nameClr, syAct + 4);
         // `namePx` rides along for the same reason the strings do: the size lives in a draw-local
         // and there is no DOM to read it back from, so a spec asserting the type hierarchy would
         // otherwise have to re-type the number and agree with a broken build by construction
@@ -16445,12 +16465,11 @@ class Component extends DCLogic {
           // it is the same "stated twice" defect the in-node pass was deleted for. The ROLE is
           // the part no shape carries, so it is the part that gets written. Category survives
           // only where there is no role to name.
-          const nm = n.ty === "positions" ? this.posFamily(n.t) : this.displayName(n);
           const rl = this.roleLabel();
           const kick = rl
             ? String(rl).toUpperCase()
             : (n.ty === "positions" ? "POSITION" : n.ty === "submissions" ? "SUBMISSION" : "TRANSITION");
-          richLabel(this.focusIdx, kick, this.myColor(n), nm, true);
+          richLabel(this.focusIdx, kick, this.myColor(n), true);
         }
       }
       // ...and the SAME group for whatever pair the cursor is over, when it is not the focus's.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bjjgraph",
-  "version": "1.173.0",
+  "version": "1.173.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bjjgraph",
-      "version": "1.173.0",
+      "version": "1.173.2",
       "hasInstallScript": true,
       "devDependencies": {
         "@playwright/test": "^1.61.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bjjgraph",
-  "version": "1.173.1",
+  "version": "1.173.2",
   "description": "BJJ knowledge graph and state machine",
   "scripts": {
     "postinstall": "cd source && npm install",

--- a/tests/artifacts/first_hand_payload.json
+++ b/tests/artifacts/first_hand_payload.json
@@ -1,11 +1,11 @@
 {
  "_meta": {
   "note": "Written by e2e/journeys/payload-first-hand.spec.ts. Observed only — the ceilings live in budget_neural.json.",
-  "measured_at": "2026-09-03T08:43:00.382Z"
+  "measured_at": "2026-09-03T20:16:28.615Z"
  },
  "request_count": 19,
- "first_hand_raw_bytes": 1609357,
- "first_hand_gzip_bytes": 382682,
+ "first_hand_raw_bytes": 1617198,
+ "first_hand_gzip_bytes": 384983,
  "start_position": "Gogoplata Control Top",
  "charged_from_disk": [],
  "heaviest": [
@@ -16,8 +16,8 @@
   },
   {
    "path": "/static/neural/app/neural.js",
-   "raw": 513170,
-   "gzip": 153790
+   "raw": 521090,
+   "gzip": 156071
   },
   {
    "path": "/static/neural/flashcards/_index.json",
@@ -27,7 +27,7 @@
   {
    "path": "/static/neural/curriculum.json",
    "raw": 97530,
-   "gzip": 21039
+   "gzip": 21076
   },
   {
    "path": "/postscript.js",
@@ -41,8 +41,8 @@
   },
   {
    "path": "/static/neural/app/neural.css",
-   "raw": 35354,
-   "gzip": 7695
+   "raw": 35275,
+   "gzip": 7678
   },
   {
    "path": "/",

--- a/tests/neural_type_scale.test.mjs
+++ b/tests/neural_type_scale.test.mjs
@@ -41,14 +41,19 @@ import { dirname, resolve } from "node:path";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const APP = resolve(HERE, "../neural/src/app.src.jsx");
 const TPL = resolve(HERE, "../neural/src/xdc-template.html");
+const WIRE = JSON.parse(
+  readFileSync(
+    resolve(HERE, "../source/quartz/static/neural/graph-data.json"),
+    "utf8",
+  ),
+);
 const src = readFileSync(APP, "utf8");
 const tpl = readFileSync(TPL, "utf8");
 
-const Component = new Function(
-  "DCLogic",
-  "React",
-  `${src}\nreturn Component;`,
-)(class DCLogic {}, { createRef: () => ({ current: null }) });
+const Component = new Function("DCLogic", "React", `${src}\nreturn Component;`)(
+  class DCLogic {},
+  { createRef: () => ({ current: null }) },
+);
 
 /** The real instance at a given viewport width. `isMobile()` reads `this.W` (falling back to
  *  `window.innerWidth`, which does not exist here), so the width must be set explicitly. */
@@ -56,6 +61,72 @@ function at(width) {
   const a = new Component({});
   a.W = width;
   return a;
+}
+
+/** A recording 2D context: `draw()` runs unchanged, but no browser/GPU is required. */
+function recordingContext(texts) {
+  const state = {};
+  const gradient = { addColorStop() {} };
+  return new Proxy(state, {
+    get(target, key) {
+      if (key in target) return target[key];
+      if (key === "fillText")
+        return (text, x, y) =>
+          texts.push({ text: String(text), x, y, font: target.font });
+      if (key === "measureText")
+        return (text) => {
+          const match = String(target.font || "").match(/([\d.]+)px/);
+          const px = match ? parseFloat(match[1]) : 12;
+          return { width: String(text).length * px * 0.55 };
+        };
+      if (key === "createLinearGradient" || key === "createRadialGradient")
+        return () => gradient;
+      return () => {};
+    },
+    set(target, key, value) {
+      target[key] = value;
+      return true;
+    },
+  });
+}
+
+/** Run the real wire through the real ingest and canvas draw paths at one camera scale. */
+function labelApp() {
+  const a = at(495);
+  a.props = {};
+  a.settings = {};
+  a.beats = [];
+  a.track = () => {};
+  a._saveProgress = () => {};
+  a.get = (_key, fallback) => fallback;
+  a.set = () => {};
+  a.ingest(structuredClone(WIRE));
+  const focus = a.nodes.find(
+    (n) => n.t === "Trap and Roll from Mount" && n.role === "defender",
+  );
+  assert.ok(focus, "the reported defender node exists in the shipped wire");
+  const partner = a.nodes[focus.pi];
+  assert.ok(partner, "the reported node has its attacker pair");
+  const texts = [];
+  a.ctx = recordingContext(texts);
+  a.H = 600;
+  a.dpr = 1;
+  a.alpha = 1;
+  a.now = 10;
+  a.startTime = 0;
+  a.focusIdx = focus.idx;
+  a.currentPos = focus.idx;
+  a.playerRole = "top";
+  a.paused = true;
+  a.pulse = null;
+  a.activeMove = null;
+  a.optionIdxs = [];
+  a.trail = [];
+  a.ripples = [];
+  a.anim = (_key, fallback) => fallback;
+  a.updateNodeCard = () => {};
+  a.cam = { cx: focus.x, cy: (focus.y + partner.y) / 2, vw: a.W / 3 };
+  return { a, texts };
 }
 
 const WIDTHS = [320, 360, 390, 414, 640, 641, 768, 1024, 1280, 1440];
@@ -66,8 +137,14 @@ test("the announcer never outranks the name of the state it is describing", () =
     const a = at(w);
     const name = a.nameFontPx();
     const ann = a.announcerPx();
-    assert.ok(Number.isFinite(name) && name > 0, `${w}px: nameFontPx() must be a real size, got ${name}`);
-    assert.ok(Number.isFinite(ann) && ann > 0, `${w}px: announcerPx() must be a real size, got ${ann}`);
+    assert.ok(
+      Number.isFinite(name) && name > 0,
+      `${w}px: nameFontPx() must be a real size, got ${name}`,
+    );
+    assert.ok(
+      Number.isFinite(ann) && ann > 0,
+      `${w}px: announcerPx() must be a real size, got ${ann}`,
+    );
     // a full step, not a rounding: the owner asked for a hierarchy you can see, and 1px is not one
     assert.ok(
       ann <= name / 1.15,
@@ -76,7 +153,11 @@ test("the announcer never outranks the name of the state it is describing", () =
     checked++;
   }
   // POSITIVE COVERAGE (CLAUDE.md 6.6): "matched nothing" must never look like "all fine"
-  assert.equal(checked, WIDTHS.length, "every viewport in the table must have been checked");
+  assert.equal(
+    checked,
+    WIDTHS.length,
+    "every viewport in the table must have been checked",
+  );
 });
 
 test("the phone keeps the label size its @curated width bound was measured at", () => {
@@ -84,9 +165,19 @@ test("the phone keeps the label size its @curated width bound was measured at", 
   // `_labelWidthPx`, and measured (tests/artifacts/_label_size_probe.mjs) 320px admits at most
   // 19px before that deploy gate goes red. Growing this without re-running that probe is the
   // failure this test exists to make loud.
-  assert.ok(at(320).nameFontPx() <= 19, "320px: the narrow label size must stay inside dual-pair.spec.ts's bound");
-  assert.equal(at(640).nameFontPx(), at(320).nameFontPx(), "one narrow value up to isMobile()'s own 640px edge");
-  assert.ok(at(641).nameFontPx() > at(640).nameFontPx(), "…and the wide step must actually be a step");
+  assert.ok(
+    at(320).nameFontPx() <= 19,
+    "320px: the narrow label size must stay inside dual-pair.spec.ts's bound",
+  );
+  assert.equal(
+    at(640).nameFontPx(),
+    at(320).nameFontPx(),
+    "one narrow value up to isMobile()'s own 640px edge",
+  );
+  assert.ok(
+    at(641).nameFontPx() > at(640).nameFontPx(),
+    "…and the wide step must actually be a step",
+  );
 });
 
 test("the draw, richLabel and _labelWidthPx all read nameFontPx() — no hand-copied mirrors", () => {
@@ -95,11 +186,18 @@ test("the draw, richLabel and _labelWidthPx all read nameFontPx() — no hand-co
   // sites is invisible to every other gate in the repo.
   const sites = [
     [/const namePx = focused \? this\.nameFontPx\(\) : 15;/, "pair-group draw"],
-    [/const rNamePx = big \? this\.nameFontPx\(\) : 13;/, "richLabel big branch"],
+    [
+      /const rNamePx = big \? this\.nameFontPx\(\) : 13;/,
+      "richLabel big branch",
+    ],
     [/const px = this\.nameFontPx\(\);/, "_labelWidthPx"],
   ];
   for (const [re, what] of sites) {
-    assert.equal((src.match(re) || []).length, 1, `${what} must read nameFontPx() exactly once`);
+    assert.equal(
+      (src.match(re) || []).length,
+      1,
+      `${what} must read nameFontPx() exactly once`,
+    );
   }
   // and the literal that used to live there must be gone from every canvas font string
   assert.equal(
@@ -109,20 +207,98 @@ test("the draw, richLabel and _labelWidthPx all read nameFontPx() — no hand-co
   );
   // the drawn size must be PUBLISHED, or the journey gate has to re-type it and would agree with
   // a broken build by construction (CLAUDE.md 6.3)
-  assert.match(src, /_lastPairLabel = \{[^}]*namePx: namePx/, "_lastPairLabel must publish namePx");
-  assert.match(src, /_lastRichLabel = \{[^}]*namePx: rNamePx/, "_lastRichLabel must publish namePx");
+  assert.match(
+    src,
+    /_lastPairLabel = \{[^}]*namePx: namePx/,
+    "_lastPairLabel must publish namePx",
+  );
+  assert.match(
+    src,
+    /_lastRichLabel = \{[^}]*namePx: rNamePx/,
+    "_lastRichLabel must publish namePx",
+  );
+});
+
+test("a qualified focus keeps separate, compact subtitle rows across label LODs", () => {
+  const { a, texts } = labelApp();
+
+  a.draw();
+  const split = a._lastPairLabel;
+  assert.ok(a._lodK > 0.5, `the pair must be split, got LOD ${a._lodK}`);
+  assert.ok(split, "the real pair renderer emitted a focused label");
+  assert.equal(split.main, "Trap and Roll");
+  assert.equal(split.qual, "from Mount");
+  assert.equal(split.sub, "DEFENDING");
+  assert.equal(split.above, false, "DEFENDING is the lower role");
+  assert.equal(
+    split.subY - split.qualY,
+    split.qualY - split.nameY,
+    "the qualifier and lower role use the same compact baseline rhythm",
+  );
+  assert.ok(
+    texts.some((row) => row.text === "Trap and Roll"),
+    "the split canvas drew the short title",
+  );
+  assert.ok(
+    texts.some((row) => row.text === "from Mount"),
+    "the split canvas drew the qualifier",
+  );
+
+  texts.length = 0;
+  a.cam.vw = a.W; // scale 1: below pairGroup's merge threshold
+  a.draw();
+  const merged = a._lastRichLabel;
+  assert.ok(a._lodK < 0.5, `the pair must be merged, got LOD ${a._lodK}`);
+  assert.equal(a._lastPairLabel, null, "the split-pair renderer stood down");
+  assert.ok(merged, "the real merged renderer emitted a focused label");
+  assert.equal(merged.name, "Trap and Roll", "the title stays short");
+  assert.equal(
+    merged.qual,
+    "from Mount",
+    "the origin remains its own subtitle",
+  );
+  assert.ok(
+    merged.qualY > merged.nameY,
+    "the qualifier baseline is below the title",
+  );
+  assert.ok(
+    texts.some((row) => row.text === "Trap and Roll"),
+    "the merged canvas drew the short title",
+  );
+  assert.ok(
+    texts.some((row) => row.text === "from Mount"),
+    "the merged canvas drew the qualifier",
+  );
+  assert.ok(
+    !texts.some((row) => row.text === "Trap and Roll from Mount"),
+    "no canvas row recomposes the qualifier into the title",
+  );
 });
 
 test("the template's announcer size is a first-frame guess the app overwrites", () => {
   const row = tpl.match(/<div ref="\{\{ evTextRef \}\}" style="([^"]*)"/);
-  assert.ok(row, "the announcer text row must still be findable in xdc-template.html");
+  assert.ok(
+    row,
+    "the announcer text row must still be findable in xdc-template.html",
+  );
   const px = row[1].match(/font-size:([\d.]+)px;/);
-  assert.ok(px, `the announcer row must carry a plain px font-size, got: ${row[1].slice(0, 60)}`);
+  assert.ok(
+    px,
+    `the announcer row must carry a plain px font-size, got: ${row[1].slice(0, 60)}`,
+  );
   const guess = parseFloat(px[1]);
   // it is never READ by the app, but a guess further from the truth than the step it is guessing
   // means a visible reflow on the first resize — so pin it to the wide value it stands in for.
-  assert.equal(guess, at(1280).announcerPx(), "the first-frame guess must match announcerPx() at desktop width");
-  assert.match(src, /_applyTypeScale\(\)/, "…and _applyTypeScale must exist to overwrite it");
+  assert.equal(
+    guess,
+    at(1280).announcerPx(),
+    "the first-frame guess must match announcerPx() at desktop width",
+  );
+  assert.match(
+    src,
+    /_applyTypeScale\(\)/,
+    "…and _applyTypeScale must exist to overwrite it",
+  );
   assert.match(
     src,
     /resize\(\)\s*\{[\s\S]*?this\._applyTypeScale\(\);[\s\S]*?\n  \}/,


### PR DESCRIPTION
## Summary
- keep technique origin qualifiers on their own subtitle row at every canvas LOD
- use compact, consistent subtitle spacing for lower-role labels
- measure the widest rendered label row for framing

## Verification
- `npm run dev:neural:app` — bundle rebuilt from rebased `dev`
- `npm run test:units` — 235 passed
- full curated suite after rebasing — 218 passed