### PR TITLE
Fix landing focus switching from Bottom to Top

### DIFF
--- a/e2e/journeys/landing-role.spec.ts
+++ b/e2e/journeys/landing-role.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+import { journey } from "../dsl";
+
+// Exercise the normal opening and restart, without rigStart (which bypasses the draw).
+// Reads the intro DOM and draw()'s published label; deleting startRoll's seat resolution
+// must fail the Bottom cases. The DSL omits dossier content; none is needed for identity.
+for (const role of ["bottom", "top"] as const) {
+  test(`@curated a ${role} opening keeps its seat from intro to landing and Carni restart`, async ({ page }) => {
+    const j = journey(page);
+    await j.boot("/", { seedRolls: { role: [role === "bottom" ? 0.9 : 0], "start-pos": [0] } });
+
+    const readSeat = () => page.evaluate(() => {
+      const a = (window as any).__neural;
+      const n = a.nodes[a.currentPos];
+      const f = a.nodes[a.focusIdx];
+      return {
+        idx: a.currentPos, role: a.playerRole, nodeRole: n.role, focusRole: f.role,
+        name: a.graphName(n), deck: a.deckKeyFor(n).key,
+        introName: a.evcTextRef.current.textContent, introRole: a.evcSubRef.current.textContent,
+        label: a._lastPairLabel,
+      };
+    });
+
+    for (const opening of ["first", "Carni"]) {
+      if (opening === "Carni") {
+        // Select the middle of Carni's slot in the actual random pool. Leave the pool and
+        // role draw intact, including the one-entry-per-position distribution.
+        const draw = await page.evaluate(() => {
+          const a = (window as any).__neural;
+          const slot = a._posIdx.findIndex((idx: number) => a.graphName(a.nodes[idx]) === "Carni");
+          return { slot, value: (slot + 0.5) / a._posIdx.length };
+        });
+        expect(draw.slot, "Carni is in the normal opening pool").toBeGreaterThanOrEqual(0);
+        await j.rig("start-pos", [draw.value]);
+        await j.rig("role", [role === "bottom" ? 0.9 : 0]);
+        await page.evaluate(() => (window as any).__neural.resetRoll());
+      }
+      // Observe the named intro BEFORE enterLand can repair or replace any state.
+      await expect.poll(async () => {
+        await j.advance(100);
+        return page.evaluate(() => {
+          const a = (window as any).__neural;
+          return a._arriveLabelT != null && !!a.evcTextRef.current.textContent;
+        });
+      }, { timeout: 30000, intervals: [10] }).toBe(true);
+      const intro = await readSeat();
+      const word = role === "bottom" ? "Bottom" : "Top";
+      expect(intro.introRole).toBe(word);
+      expect(intro.introName).toBe(intro.name);
+      expect(intro.nodeRole, "the named seat owns the opening node").toBe(role);
+      expect(intro.focusRole, "the camera follows that seat during the flight").toBe(role);
+      if (opening === "Carni") expect(intro.name).toBe("Carni");
+
+      await j.nextHand(30000);
+      await j.advance(300);
+      const landed = await readSeat();
+      expect(landed.idx, "the intro hands off to the same node").toBe(intro.idx);
+      expect(landed.role).toBe(role);
+      expect(landed.focusRole).toBe(role);
+      expect(landed.deck).toBe(`${landed.name}|${word}`);
+      expect(landed.label, "the graph drew its focused pair label").not.toBeNull();
+      expect(landed.label.focused).toBe(true);
+      expect(landed.label.main).toBe(landed.name);
+      expect(landed.label.sub).toBe(word.toUpperCase());
+    }
+  });
+}

--- a/e2e/journeys/start-from.spec.ts
+++ b/e2e/journeys/start-from.spec.ts
@@ -89,7 +89,7 @@ const rigAmbient = async (j: any, n: number) => {
 type WeakRow = { idx: number; role: string; deck: string; w: number };
 type WeakNode = {
   idx: number; t: string; ty: string; rep?: boolean;
-  posId: string | null; fromPositionId: string | null; fromRole: string | null;
+  posId: string | null; fromPositionId: string | null; fromRole: string | null; role?: string;
 };
 type NeuralApp = {
   nodes: WeakNode[];
@@ -398,6 +398,8 @@ test("@curated a weak-spots roll opens on the biggest leak, on its seat — and 
     return {
       len: win.length,
       w0,
+      openingPosId: w0 ? a.nodes[w0.idx].posId : null,
+      nodeRole: a.nodes[a.currentPos].role,
       spot: a._startSpot,
       current: { idx: a.currentPos, posId: a.nodes[a.currentPos].posId, role: a.playerRole },
       wire: n ? { ty: n.ty, posId: n.posId, fromPositionId: n.fromPositionId, fromRole: n.fromRole } : null,
@@ -405,7 +407,8 @@ test("@curated a weak-spots roll opens on the biggest leak, on its seat — and 
     };
   });
   expect(r.len, "the window the draw used is PUBLISHED").toBeGreaterThan(0);
-  expect(r.current.idx, "the roll opened on the first row's state").toBe(r.w0.idx);
+  expect(r.current.posId, "the roll opened on the first row's position").toBe(r.openingPosId);
+  expect(r.nodeRole, "the focused node is the spot's seat").toBe(r.w0.role);
   expect(r.current.role, "…on the spot's own seat, over the rigged top role draw").toBe(r.w0.role);
   expect(r.spot, "…and the crack is named for the toast").toBe(r.w0.deck);
   expect(r.rigLeft, "exactly one start-pos draw, as in every other mode").toBe(0);
@@ -453,12 +456,12 @@ test("@curated a bottom-seat spot seats you bottom even when the role draw says 
     const a = (window as unknown as { __neural: NeuralApp }).__neural; // page boundary: the app's own debug handle
     const win = a._lastWeakWindow || [];
     const k = win.findIndex((row) => row.role === "bottom");
-    if (k < 0) return { k, mid: 0, row: null };
+    if (k < 0) return { k, mid: 0, row: null, posId: null };
     const total = win.reduce((acc, row) => acc + row.w, 0);
     let below = 0;
     for (let i = 0; i < k; i++) below += win[i].w;
     // the row's cumulative-weight midpoint, computed from the PUBLISHED window's own weights
-    return { k, mid: (below + win[k].w / 2) / total, row: win[k] };
+    return { k, mid: (below + win[k].w / 2) / total, row: win[k], posId: a.nodes[win[k].idx].posId };
   });
   expect(t.k, "some window row is a bottom seat — games leak from under people too").toBeGreaterThanOrEqual(0);
 
@@ -468,9 +471,10 @@ test("@curated a bottom-seat spot seats you bottom even when the role draw says 
   expect(s.hand).toBeGreaterThan(0);
   const after = await page.evaluate(() => {
     const a = (window as unknown as { __neural: NeuralApp }).__neural; // page boundary: the app's own debug handle
-    return { idx: a.currentPos, role: a.playerRole };
+    return { posId: a.nodes[a.currentPos].posId, role: a.playerRole, nodeRole: a.nodes[a.currentPos].role };
   });
-  expect(after.idx, "the draw landed the bottom-seat row").toBe(t.row!.idx);
+  expect(after.posId, "the draw landed the bottom-seat row's position").toBe(t.posId);
+  expect(after.nodeRole, "the graph focuses the bottom member").toBe("bottom");
   expect(after.role, "…and the SEAT is the spot's, overriding the rigged top role").toBe("bottom");
 });
 

--- a/neural/src/app.src.jsx
+++ b/neural/src/app.src.jsx
@@ -14541,6 +14541,10 @@ class Component extends DCLogic {
     } else {
       this.currentPos = positions[(this.rng("start-pos") * positions.length) | 0];
     }
+    // The draw is over sites (top representatives); the roll stands on the chosen SEAT.
+    // Resolve before prefetch, focus and the staged intro so Bottom never flies to a Top orb.
+    const start = this.nodes[this.currentPos];
+    if (start.pairId && start.role !== this.playerRole && start.pi >= 0) this.currentPos = start.pi;
     this._prefetchLandDeck(this.currentPos); // the intro is the deck's runway (v1.106.6)
     const lad = this.ladderState();
     this.fx("stakes", { rank: lad.rank, opponent: lad.opponent });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bjjgraph",
-  "version": "1.176.6",
+  "version": "1.176.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bjjgraph",
-      "version": "1.176.6",
+      "version": "1.176.7",
       "hasInstallScript": true,
       "devDependencies": {
         "@playwright/test": "^1.61.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bjjgraph",
-  "version": "1.176.6",
+  "version": "1.176.7",
   "description": "BJJ knowledge graph and state machine",
   "scripts": {
     "postinstall": "cd source && npm install",


### PR DESCRIPTION
A normal opening could announce “Carni · Bottom” while the graph focused and labelled the Top node. The random pool selects one representative per position (the top member), and `startRoll` never mapped that representative to the separately selected role.

Resolve the selected position to its matching role node before deck prefetch, camera focus, and the staged intro. This also keeps Standing and My weak spots openings on their chosen seat without changing the position distribution or consuming another random draw.

Validation:
- Fresh Top/Bottom openings and Carni restarts assert intro text, focused seat, landing deck, and the graph's rendered role label.
- Start-mode tests check the actual node role for bottom weak spots.
- Removing the fix makes the Bottom regression fail: expected bottom, received top.
- All 241 unit tests pass; all 12 focused landing/start-mode browser tests pass.
- Curated suite: 223 tests passed on the first run; the remaining payload test passed after rebuilding an outdated local site shell.
- Full production build passed. All 13 landing, start-mode, and payload browser checks passed against the rebuilt site.
